### PR TITLE
Fix A3C dtype error with torch>=1.5.0

### DIFF
--- a/pfrl/agents/a3c.py
+++ b/pfrl/agents/a3c.py
@@ -184,7 +184,7 @@ class A3C(agent.AttributeSavingMixin, agent.AsyncAgent):
             R *= self.gamma
             R += self.past_rewards[i]
             rev_returns.append(R)
-        batch_return = torch.as_tensor(list(reversed(rev_returns)))
+        batch_return = torch.as_tensor(list(reversed(rev_returns)), dtype=torch.float)
         batch_adv = batch_return - batch_v.detach().squeeze(-1)
         assert batch_log_prob.shape == (n,)
         assert batch_adv.shape == (n,)


### PR DESCRIPTION
From torch==1.5.0, `torch.as_tensor` started to respect numpy's dtype. This makes A3C fail when rewards are `numpy.float64` because the dtype of `batch_return` becomes `torch.double`, which is inconsistent with `batch_v`.

> The inferred dtype of np.float_, np.float64 scalars in tensor constructors (e.g. torch.tensor(...), torch.as_tensor(...) is now torch.float64 instead of the default dtype (usually torch.float32).

https://github.com/pytorch/pytorch/releases/tag/v1.5.0

This PR fixes the issue by explicitly setting the dtype of `batch_return`. You can confirm that it works by running `python examples/atari/reproduction/a3c/train_a3c.py --processes 1`. Before this PR, this command fails when torch>=1.5.0.