### PR TITLE
remove `gpus` argument from set_random_seed

### DIFF
--- a/examples/atari/reproduction/dqn/train_dqn.py
+++ b/examples/atari/reproduction/dqn/train_dqn.py
@@ -87,7 +87,7 @@ def main():
     logging.basicConfig(level=args.log_level)
 
     # Set a random seed used in PFRL.
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     # Set different random seeds for train and test envs.
     train_seed = args.seed

--- a/examples/atari/reproduction/iqn/train_iqn.py
+++ b/examples/atari/reproduction/iqn/train_iqn.py
@@ -84,7 +84,7 @@ def main():
     logging.basicConfig(level=args.log_level)
 
     # Set a random seed used in PFRL.
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     # Set different random seeds for train and test envs.
     train_seed = args.seed

--- a/examples/atari/reproduction/rainbow/train_rainbow.py
+++ b/examples/atari/reproduction/rainbow/train_rainbow.py
@@ -77,7 +77,7 @@ def main():
     logging.basicConfig(level=args.log_level)
 
     # Set a random seed used in PFRL.
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     # Set different random seeds for train and test envs.
     train_seed = args.seed

--- a/examples/atari/train_categorical_dqn_ale.py
+++ b/examples/atari/train_categorical_dqn_ale.py
@@ -71,7 +71,7 @@ def main():
     logging.basicConfig(level=args.log_level)
 
     # Set a random seed used in PFRL.
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     # Set different random seeds for train and test envs.
     train_seed = args.seed

--- a/examples/atari/train_dqn_ale.py
+++ b/examples/atari/train_dqn_ale.py
@@ -197,7 +197,7 @@ def main():
     logging.basicConfig(level=args.log_level)
 
     # Set a random seed used in PFRL.
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     # Set different random seeds for train and test envs.
     train_seed = args.seed

--- a/examples/atari/train_dqn_batch_ale.py
+++ b/examples/atari/train_dqn_batch_ale.py
@@ -147,7 +147,7 @@ def main():
     logging.basicConfig(level=args.log_level)
 
     # Set a random seed used in PFRL.
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     # Set different random seeds for different subprocesses.
     # If seed=0 and processes=4, subprocess seeds are [0, 1, 2, 3].

--- a/examples/atari/train_drqn_ale.py
+++ b/examples/atari/train_drqn_ale.py
@@ -173,7 +173,7 @@ def main():
     logging.basicConfig(level=args.log_level)
 
     # Set a random seed used in PFRL.
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     # Set different random seeds for train and test envs.
     train_seed = args.seed

--- a/examples/atari/train_ppo_ale.py
+++ b/examples/atari/train_ppo_ale.py
@@ -163,7 +163,7 @@ def main():
     logging.basicConfig(level=args.log_level)
 
     # Set a random seed used in PFRL.
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     # Set different random seeds for different subprocesses.
     # If seed=0 and processes=4, subprocess seeds are [0, 1, 2, 3].

--- a/examples/atlas/train_soft_actor_critic_atlas.py
+++ b/examples/atlas/train_soft_actor_critic_atlas.py
@@ -142,7 +142,7 @@ def main():
     print("Output files are saved in {}".format(args.outdir))
 
     # Set a random seed used in PFRL
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     # Set different random seeds for different subprocesses.
     # If seed=0 and processes=4, subprocess seeds are [0, 1, 2, 3].

--- a/examples/grasping/train_dqn_batch_grasping.py
+++ b/examples/grasping/train_dqn_batch_grasping.py
@@ -229,7 +229,7 @@ def main():
     logging.basicConfig(level=args.log_level)
 
     # Set a random seed used in PFRL.
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     # Set different random seeds for different subprocesses.
     # If seed=0 and processes=4, subprocess seeds are [0, 1, 2, 3].

--- a/examples/gym/train_categorical_dqn_gym.py
+++ b/examples/gym/train_categorical_dqn_gym.py
@@ -64,7 +64,7 @@ def main():
     args = parser.parse_args()
 
     # Set a random seed used in PFRL
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     args.outdir = experiments.prepare_output_dir(args, args.outdir, argv=sys.argv)
     print("Output files are saved in {}".format(args.outdir))

--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -88,13 +88,13 @@ def main():
     args = parser.parse_args()
 
     # Set a random seed used in PFRL
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     args.outdir = experiments.prepare_output_dir(args, args.outdir, argv=sys.argv)
     print("Output files are saved in {}".format(args.outdir))
 
     # Set a random seed used in PFRL.
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     # Set different random seeds for different subprocesses.
     # If seed=0 and processes=4, subprocess seeds are [0, 1, 2, 3].

--- a/examples/gym/train_reinforce_gym.py
+++ b/examples/gym/train_reinforce_gym.py
@@ -56,7 +56,7 @@ def main():
     logging.basicConfig(level=args.log_level)
 
     # Set a random seed used in PFRL.
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     args.outdir = experiments.prepare_output_dir(args, args.outdir)
 

--- a/examples/mujoco/reproduction/ddpg/train_ddpg.py
+++ b/examples/mujoco/reproduction/ddpg/train_ddpg.py
@@ -99,7 +99,7 @@ def main():
     print("Output files are saved in {}".format(args.outdir))
 
     # Set a random seed used in PFRL
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     def make_env(test):
         env = gym.make(args.env)

--- a/examples/mujoco/reproduction/ppo/train_ppo.py
+++ b/examples/mujoco/reproduction/ppo/train_ppo.py
@@ -102,7 +102,7 @@ def main():
     logging.basicConfig(level=args.log_level)
 
     # Set a random seed used in PFRL
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     # Set different random seeds for different subprocesses.
     # If seed=0 and processes=4, subprocess seeds are [0, 1, 2, 3].

--- a/examples/mujoco/reproduction/soft_actor_critic/train_soft_actor_critic.py
+++ b/examples/mujoco/reproduction/soft_actor_critic/train_soft_actor_critic.py
@@ -112,7 +112,7 @@ def main():
     print("Output files are saved in {}".format(args.outdir))
 
     # Set a random seed used in PFRL
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     # Set different random seeds for different subprocesses.
     # If seed=0 and processes=4, subprocess seeds are [0, 1, 2, 3].

--- a/examples/mujoco/reproduction/td3/train_td3.py
+++ b/examples/mujoco/reproduction/td3/train_td3.py
@@ -95,7 +95,7 @@ def main():
     print("Output files are saved in {}".format(args.outdir))
 
     # Set a random seed used in PFRL
-    utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    utils.set_random_seed(args.seed)
 
     def make_env(test):
         env = gym.make(args.env)

--- a/examples/mujoco/reproduction/trpo/train_trpo.py
+++ b/examples/mujoco/reproduction/trpo/train_trpo.py
@@ -91,7 +91,7 @@ def main():
     logging.basicConfig(level=args.log_level)
 
     # Set random seed
-    pfrl.utils.set_random_seed(args.seed, gpus=(args.gpu,))
+    pfrl.utils.set_random_seed(args.seed)
 
     args.outdir = pfrl.experiments.prepare_output_dir(args, args.outdir)
 

--- a/pfrl/utils/random_seed.py
+++ b/pfrl/utils/random_seed.py
@@ -3,7 +3,7 @@ import torch
 import numpy as np
 
 
-def set_random_seed(seed, gpus=()):
+def set_random_seed(seed):
     """Set a given random seed to Pytorch's random number generator
 
     torch.manual_seed() seeds the RNG for all devices (both CPU and CUDA)
@@ -12,8 +12,6 @@ def set_random_seed(seed, gpus=()):
 
     Args:
         seed (int): Random seed [0, 2 ** 32).
-        gpus (tuple of ints): GPU device IDs to use. Negative values are
-            ignored.
     """
     # PFRL depends on random
     random.seed(seed)


### PR DESCRIPTION
`gpus` argument of `utils.random_seed.set_random_seed` is no longer needed, since `torch.manual_seed` sets a seed for both CPU and GPU as the doc says.

Before PR:

```
$ egrep -n -r "set_random_seed\(.+," pfrl
pfrl/pfrl/utils/random_seed.py:6:def set_random_seed(seed, gpus=()):
pfrl/examples/atari/train_dqn_ale.py:200:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/atari/train_drqn_ale.py:176:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/atari/train_categorical_dqn_ale.py:74:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/atari/train_dqn_batch_ale.py:150:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/atari/train_ppo_ale.py:166:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/atari/reproduction/dqn/train_dqn.py:90:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/atari/reproduction/rainbow/train_rainbow.py:80:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/atari/reproduction/iqn/train_iqn.py:87:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/mujoco/reproduction/soft_actor_critic/train_soft_actor_critic.py:115:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/mujoco/reproduction/ddpg/train_ddpg.py:102:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/mujoco/reproduction/ppo/train_ppo.py:105:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/mujoco/reproduction/trpo/train_trpo.py:94:    pfrl.utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/mujoco/reproduction/td3/train_td3.py:98:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/grasping/train_dqn_batch_grasping.py:232:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/gym/train_reinforce_gym.py:59:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/gym/train_categorical_dqn_gym.py:67:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/gym/train_dqn_gym.py:91:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/gym/train_dqn_gym.py:97:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
pfrl/examples/atlas/train_soft_actor_critic_atlas.py:145:    utils.set_random_seed(args.seed, gpus=(args.gpu,))
```

After PR:

```
$ egrep -n -r "set_random_seed\(.+," pfrl  # no output printed
```