### PR TITLE
Update self._cumulative_steps in non-actor-learner training

### DIFF
--- a/pfrl/agents/dqn.py
+++ b/pfrl/agents/dqn.py
@@ -237,7 +237,6 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
     @property
     def cumulative_steps(self):
         # cumulative_steps counts the overall steps during the training.
-        # This property is only effective and correct in actor-learner mode.
         return self._cumulative_steps
 
     def _setup_actor_learner_training(self, n_actors, actor_update_interval):
@@ -455,6 +454,7 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
 
         for i in range(len(batch_obs)):
             self.t += 1
+            self._cumulative_steps += 1
             # Update the target network
             if self.t % self.target_update_interval == 0:
                 self.sync_target_network()


### PR DESCRIPTION
`self._cumulative_steps` was introduced for correctly counting steps in actor-learner training , but was invalid in non-actor-learner training. (See the internal repository for how it was introduced.) This PR makes it valid in both actor-learner and non-actor-learner training.

In non-actor-leaner training, it is now equivalent to `self.t`. However, `self.t` and `self._cumulative_steps` are different in actor-learner training. That is why they cannot simply merged into one.