### PR TITLE
Rainbow benchmark results

### DIFF
--- a/examples/atari/reproduction/rainbow/README.md
+++ b/examples/atari/reproduction/rainbow/README.md
@@ -27,7 +27,7 @@ To view the full list of options, either view the code or run the example with t
 
 
 ## Results
-These results reflect PFRL commit hash:  `TODO`.
+These results reflect PFRL commit hash:  `a0ad6a7`.
 
 | Results Summary ||
 | ------------- |:-------------:|
@@ -125,8 +125,8 @@ All jobs were run on a single GPU.
 | ------------- |:-------------:|
 | Mean        |  7.173 |
 | Standard deviation | 0.166|
-| Fastest time | 6.764|
-| Slowest time | 7.612|
+| Fastest run | 6.764|
+| Slowest run | 7.612|
 
 
 


### PR DESCRIPTION
I ran 
```
python getmeanscore.py --algorithm Rainbow --results-dir /Users/prabhat/pfn/pfrl_results/rainbow_short_results --evaluation-type best --time-unit day --unstructured True
```
on the internal PFN repository `prabhat/chainerrl_paper_atari`.

the flags represent the following:

- `--results-dir`: where I scp-ed the results locally. The directory name `rainbow_short_results` is just because I took a shortened subset of the files I needed to produce results (i.e. best.json and scores.txt)
-  `--time-unit day` means we compute the times and produce the tables in terms of "days" (as opposed to hours like Mujoco domains)
- `--evaluation-type best` refers to re-evaluating the best network (the evaluation protocol)