### PR TITLE
IQN Benchmark results

### DIFF
--- a/examples/atari/reproduction/iqn/README.md
+++ b/examples/atari/reproduction/iqn/README.md
@@ -27,81 +27,80 @@ To view the full list of options, either view the code or run the example with t
 
 
 ## Results
-**NOTE: These results reflect scores from our predecessor library, ChainerRL. We will release benchmarks for PFRL in the future.**
-
-These results reflect ChainerRL  `v0.6.0`. We use the same evaluation protocol used in the IQN paper.
+These results reflect PFRL commit hash: `a0ad6a7`. We use the same evaluation protocol used in the IQN paper.
 
 
 | Results Summary ||
 | ------------- |:-------------:|
-| Number of seeds | 2 |
+| Reporting Protocol | The highest mean intermediate evaluation score |
+| Number of seeds | 3 |
 | Number of common domains | 55 |
-| Number of domains where paper scores higher | 25 |
-| Number of domains where ChainerRL scores higher | 27 |
-| Number of ties between paper and ChainerRL | 3 |
+| Number of domains where paper scores higher | 23 |
+| Number of domains where PFRL scores higher | 26 |
+| Number of ties between paper and PFRL | 6 | 
 
 
-| Game        | ChainerRL Score           | Original Reported Scores |
+| Game        | PFRL Score           | Original Reported Scores |
 | ------------- |:-------------:|:-------------:|
-| AirRaid | 9672.1| N/A|
-| Alien | **12484.3**| 7022|
-| Amidar | 2392.3| **2946**|
-| Assault | 24731.9| **29091**|
-| Asterix | **454846.7**| 342016|
-| Asteroids | **3885.9**| 2898|
-| Atlantis | 946912.5| **978200**|
-| BankHeist | 1326.3| **1416**|
-| BattleZone | **69316.2**| 42244|
-| BeamRider | 38111.4| **42776**|
-| Berzerk | **138167.9**| 1053|
-| Bowling | 84.3| **86.5**|
+| AirRaid | 10124.5| N/A|
+| Alien | **11625.6**| 7022|
+| Amidar | 1984.1| **2946**|
+| Assault | 23126.2| **29091**|
+| Asterix | **485221.5**| 342016|
+| Asteroids | **3662.0**| 2898|
+| Atlantis | 939633.3| **978200**|
+| BankHeist | 1338.2| **1416**|
+| BattleZone | **61428.6**| 42244|
+| BeamRider | 35294.8| **42776**|
+| Berzerk | **2295.6**| 1053|
+| Bowling | **94.5**| 86.5|
 | Boxing | **99.9**| 99.8|
-| Breakout | 658.6| **734**|
-| Carnival | 5267.2| N/A|
-| Centipede | 11265.2| **11561**|
-| ChopperCommand | **43466.9**| 16836|
-| CrazyClimber | 178111.6| **179082**|
-| DemonAttack | **134637.5**| 128580|
-| DoubleDunk | **8.3**| 5.6|
-| Enduro | **2363.3**| 2359|
-| FishingDerby | **39.3**| 33.8|
-| Freeway | **34.0**| **34.0**|
-| Frostbite | **8531.3**| 4342|
-| Gopher | 116037.5| **118365**|
-| Gravitar | **1010.8**| 911|
-| Hero | 27639.9| **28386**|
-| IceHockey | -0.3| **0.2**|
-| Jamesbond | 27959.5| **35108**|
-| JourneyEscape | -685.6| N/A|
-| Kangaroo | **15517.7**| 15487|
-| Krull | 9809.3| **10707**|
-| KungFuMaster | **87566.3**| 73512|
-| MontezumaRevenge | **0.6**| 0.0|
-| MsPacman | 5786.5| **6349**|
-| NameThisGame | **23151.3**| 22682|
-| Phoenix | **145318.8**| 56599|
+| Breakout | 708.0| **734**|
+| Carnival | 5836.8| N/A|
+| Centipede | 10702.5| **11561**|
+| ChopperCommand | **23182.5**| 16836|
+| CrazyClimber | 172486.1| **179082**|
+| DemonAttack | **132576.7**| 128580|
+| DoubleDunk | -0.1| **5.6**|
+| Enduro | 2359.0| 2359|
+| FishingDerby | **43.8**| 33.8|
+| Freeway | 34.0| 34.0|
+| Frostbite | **7820.7**| 4342|
+| Gopher | 112949.3| **118365**|
+| Gravitar | **1045.9**| 911|
+| Hero | 25299.7| **28386**|
+| IceHockey | **2.5**| 0.2|
+| Jamesbond | 26284.1| **35108**|
+| JourneyEscape | -640.8| N/A|
+| Kangaroo | 15014.8| **15487**|
+| Krull | 9625.8| **10707**|
+| KungFuMaster | **85625.3**| 73512|
+| MontezumaRevenge | 0.0| 0.0|
+| MsPacman | 4818.8| **6349**|
+| NameThisGame | 22553.7| **22682**|
+| Phoenix | **138020.8**| 56599|
 | Pitfall | 0.0| 0.0|
-| Pong | **21.0**| **21.0**|
-| Pooyan | 28041.5| N/A|
-| PrivateEye | **289.9**| 200|
-| Qbert | 24950.3| **25750**|
-| Riverraid | **20716.1**| 17765|
-| RoadRunner | **63523.6**| 57900|
-| Robotank | **77.1**| 62.5|
-| Seaquest | 27045.5| **30140**|
-| Skiing | -9354.7| **-9289**|
-| Solaris | 7423.3| **8007**|
-| SpaceInvaders | 27810.9| **28888**|
-| StarGunner | **189208.0**| 74677|
-| Tennis | **23.8**| 23.6|
-| TimePilot | **12758.3**| 12236|
-| Tutankham | **337.4**| 293|
-| UpNDown | 83140.0| **88148**|
-| Venture | 289.0| **1318**|
-| VideoPinball | 664013.5| **698045**|
-| WizardOfWor | 20892.8| **31190**|
-| YarsRevenge | **30385.0**| 28379|
-| Zaxxon | 14754.4| **21772**|
+| Pong | 21.0| 21.0|
+| Pooyan | 18799.4| N/A|
+| PrivateEye | **1685.7**| 200|
+| Qbert | **26133.3**| 25750|
+| Riverraid | **21663.9**| 17765|
+| RoadRunner | **66602.9**| 57900|
+| Robotank | **76.2**| 62.5|
+| Seaquest | 27528.7| **30140**|
+| Skiing | **-9256.7**| -9289|
+| Solaris | 7606.3| **8007**|
+| SpaceInvaders | **30784.6**| 28888|
+| StarGunner | **172230.3**| 74677|
+| Tennis | 23.6| 23.6|
+| TimePilot | 11648.8| **12236**|
+| Tutankham | **345.1**| 293|
+| UpNDown | 84747.0| **88148**|
+| Venture | 1027.1| **1318**|
+| VideoPinball | **714777.3**| 698045|
+| WizardOfWor | 24954.3| **31190**|
+| YarsRevenge | **29202.1**| 28379|
+| Zaxxon | 17905.8| **21772**|
 
 
 ## Evaluation Protocol
@@ -118,11 +117,12 @@ Our evaluation protocol is designed to mirror the evaluation protocol of the ori
 
 ## Training times
 
-| Training time (in days) across all domains  |               |
-| --------------------------------------------|:-------------:|
-| Mean |  9.21 |
-| Min  | 8.52 (YarsRevenge) |
-| Max  | 10.01 (Freeway) |
+| Training time (in days) across all runs (# domains x # seeds) | |
+| ------------- |:-------------:|
+| Mean        |  4.866 |
+| Standard deviation | 0.152|
+| Fastest run | 4.472|
+| Slowest run | 5.295|
 
 
 


### PR DESCRIPTION
I ran 
`python getmeanscore.py --algorithm IQN --results-dir /Users/prabhat/pfn/pfrl_results/iqn_results --evaluation-type intermediate --time-unit day --unstructured True`

on the internal PFN repository `prabhat/chainerrl_paper_atari`.

The flags represent the following:

- `--time-unit day` means we compute the times and produce the tables in terms of "days" (as opposed to hours like Mujoco domains)
- `--evaluation-type intermediate` means we report the highest intermediate evaluation
- `--unstructured True` refers to the format of the data (if the data is not sorted into seeds) 