### PR TITLE
Make update_counter multiprocess safe

### DIFF
--- a/pfrl/agents/dqn.py
+++ b/pfrl/agents/dqn.py
@@ -241,7 +241,9 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         # cumulative_steps counts the overall steps during the training.
         return self._cumulative_steps
 
-    def _setup_actor_learner_training(self, n_actors, actor_update_interval, update_counter):
+    def _setup_actor_learner_training(
+        self, n_actors, actor_update_interval, update_counter
+    ):
         assert actor_update_interval > 0
 
         self.actor_update_interval = actor_update_interval
@@ -632,8 +634,7 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
                 self._poll_pipe(i, pipe, replay_buffer_lock, exception_event)
 
     def setup_actor_learner_training(
-        self, n_actors,
-        update_counter=None, n_updates=None, actor_update_interval=8
+        self, n_actors, update_counter=None, n_updates=None, actor_update_interval=8
     ):
         if update_counter is None:
             update_counter = mp.Value(ctypes.c_ulong)


### PR DESCRIPTION
This PR changes the type of `update_counter` from a pure int to a
`multiprocessing.value`. The reason behind this change is
that the `update_counter` is used as the
`generation id` in the `grpc` mode and is shared with the server process.

A lock is added to secure that no broken model will be shared between
the server and learner in grpc mode.