### PR TITLE
Enable auto assignment of PR reviewers

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,17 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: false
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - keisuke-nakata
+  - marioyc
+  - muupan
+  - prabhatnagarajan
+  - ummavi
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 1

--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -1,0 +1,9 @@
+name: 'Auto Assign'
+
+on: pull_request
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@eea5ee2e4421078bf163287c05e72d162781b30c


### PR DESCRIPTION
This PR will enable auto assignment of PR reviewers using GitHub Actions. A reviewer is chosen randomly from the list in `.github/auto_assign.yml` when a PR is opened (excluding the PR's author), which is the config file for https://github.com/kentaro-m/auto-assign-action.

~See https://github.com/pfnet/pfrl/pull/42 for how it works.~ It seems already enabled for this PR. See what `github-actions` bot does.