### PR TITLE
Implement optimize_hooks in agents

### DIFF
--- a/pfrl/agents/a2c.py
+++ b/pfrl/agents/a2c.py
@@ -45,6 +45,7 @@ class A2C(agent.AttributeSavingMixin, agent.BatchAgent):
             to record statistics.
         batch_states (callable): method which makes a batch of observations.
             default is `pfrl.utils.batch_states.batch_states`
+        optimize_hooks(list of callables): Hooks when optimizer.step() is called
     """
 
     process_idx = None

--- a/pfrl/agents/a2c.py
+++ b/pfrl/agents/a2c.py
@@ -70,6 +70,7 @@ class A2C(agent.AttributeSavingMixin, agent.BatchAgent):
         average_entropy_decay=0.999,
         average_value_decay=0.999,
         batch_states=batch_states,
+        optimize_hooks=[],
     ):
 
         self.model = model
@@ -107,6 +108,8 @@ class A2C(agent.AttributeSavingMixin, agent.BatchAgent):
         self.average_actor_loss = 0
         self.average_value = 0
         self.average_entropy = 0
+
+        self.optimize_hooks = optimize_hooks
 
     def _flush_storage(self, obs_shape, action):
         obs_shape = obs_shape[1:]
@@ -201,6 +204,9 @@ class A2C(agent.AttributeSavingMixin, agent.BatchAgent):
         self.states[0] = self.states[-1]
 
         self.t_start = self.t
+
+        for hook in self.optimize_hooks:
+            hook(self, self.optimizer)
 
         # Update stats
         self.average_actor_loss += (1 - self.average_actor_loss_decay) * (

--- a/pfrl/agents/a3c.py
+++ b/pfrl/agents/a3c.py
@@ -65,6 +65,7 @@ class A3C(agent.AttributeSavingMixin, agent.AsyncAgent):
         average_entropy_decay=0.999,
         average_value_decay=0.999,
         batch_states=batch_states,
+        optimize_hooks=[],
     ):
 
         # Globally shared model
@@ -107,6 +108,8 @@ class A3C(agent.AttributeSavingMixin, agent.AsyncAgent):
         # Stats
         self.average_value = 0
         self.average_entropy = 0
+
+        self.optimize_hooks = optimize_hooks
 
     def sync_parameters(self):
         copy_param.copy_param(target_link=self.model, source_link=self.shared_model)
@@ -216,6 +219,8 @@ class A3C(agent.AttributeSavingMixin, agent.AsyncAgent):
         copy_param.copy_grad(target_link=self.shared_model, source_link=self.model)
         # Update the globally shared model
         self.optimizer.step()
+        for hook in self.optimize_hooks:
+            hook(self, self.optimizer)
         if self.process_idx == 0:
             logger.debug("update")
 

--- a/pfrl/agents/a3c.py
+++ b/pfrl/agents/a3c.py
@@ -40,6 +40,8 @@ class A3C(agent.AttributeSavingMixin, agent.AsyncAgent):
             `pfrl.nn.StatelessRecurrent`.
         batch_states (callable): method which makes a batch of observations.
             default is `pfrl.utils.batch_states.batch_states`
+        optimize_hooks(list of callables): Hooks when optimizer.step() is called
+
     """
 
     process_idx = None

--- a/pfrl/agents/acer.py
+++ b/pfrl/agents/acer.py
@@ -329,6 +329,7 @@ class ACER(agent.AttributeSavingMixin, agent.AsyncAgent):
         average_value_decay=0.999,
         average_kl_decay=0.999,
         logger=None,
+        optimize_hooks=[],
     ):
 
         # Globally shared model
@@ -370,6 +371,7 @@ class ACER(agent.AttributeSavingMixin, agent.AsyncAgent):
         self.t = 0
         self.last_state = None
         self.last_action = None
+        self.optimize_hooks = optimize_hooks
 
         # Recurrent states of the model
         self.train_recurrent_states = None
@@ -589,6 +591,9 @@ class ACER(agent.AttributeSavingMixin, agent.AsyncAgent):
         # Copy the gradients to the globally shared model
         copy_param.copy_grad(target_link=self.shared_model, source_link=self.model)
         self.optimizer.step()
+
+        for hook in self.optimize_hooks:
+            hook(self, self.optimizer)
 
         self.sync_parameters()
 

--- a/pfrl/agents/acer.py
+++ b/pfrl/agents/acer.py
@@ -297,6 +297,7 @@ class ACER(agent.AttributeSavingMixin, agent.AsyncAgent):
             to record statistics.
         average_kl_decay (float): Decay rate of kl value. Used only to record
             statistics.
+        optimize_hooks(list of callables): Hooks when optimizer.step() is called
     """
 
     process_idx = None

--- a/pfrl/agents/ddpg.py
+++ b/pfrl/agents/ddpg.py
@@ -55,6 +55,7 @@ class DDPG(AttributeSavingMixin, BatchAgent):
         burnin_action_func (callable or None): If not None, this callable
             object is used to select actions before the model is updated
             one or more times during training.
+        optimize_hooks(list of callables): Hooks when optimizer.step() is called
     """
 
     saved_attributes = ("model", "target_model", "actor_optimizer", "critic_optimizer")

--- a/pfrl/agents/dqn.py
+++ b/pfrl/agents/dqn.py
@@ -136,6 +136,7 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
             manner.
         max_grad_norm (float or None): Maximum L2 norm of the gradient used for
             gradient clipping. If set to None, the gradient is not clipped.
+        optimize_hooks(list of callables): Hooks when optimizer.step() is called
     """
 
     saved_attributes = ("model", "target_model", "optimizer")

--- a/pfrl/agents/dqn.py
+++ b/pfrl/agents/dqn.py
@@ -163,6 +163,7 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         batch_states=batch_states,
         recurrent=False,
         max_grad_norm=None,
+        optimize_hooks=[],
     ):
         self.model = q_function
 
@@ -228,6 +229,8 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         self.train_recurrent_states = None
         self.train_prev_recurrent_states = None
         self.test_recurrent_states = None
+
+        self.optimize_hooks = optimize_hooks
 
         # Error checking
         if (
@@ -327,6 +330,8 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
             pfrl.utils.clip_l2_grad_norm_(self.model.parameters(), self.max_grad_norm)
         self.optimizer.step()
         self.optim_t += 1
+        for hook in self.optimize_hooks:
+            hook(self, self.optimizer)
 
     def update_from_episodes(self, episodes, errors_out=None):
         assert errors_out is None, "Recurrent DQN does not support PrioritizedBuffer"
@@ -346,6 +351,8 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
             pfrl.utils.clip_l2_grad_norm_(self.model.parameters(), self.max_grad_norm)
         self.optimizer.step()
         self.optim_t += 1
+        for hook in self.optimize_hooks:
+            hook(self, self.optimizer)
 
     def _compute_target_values(self, exp_batch):
         batch_next_state = exp_batch["next_state"]

--- a/pfrl/agents/ppo.py
+++ b/pfrl/agents/ppo.py
@@ -299,6 +299,7 @@ class PPO(agent.AttributeSavingMixin, agent.BatchAgent):
             It's updated after the model is updated.
         n_updates: Number of model updates so far.
         explained_variance: Explained variance computed from the last batch.
+        optimize_hooks(list of callables): Hooks when optimizer.step() is called
     """
 
     saved_attributes = ("model", "optimizer", "obs_normalizer")

--- a/pfrl/agents/reinforce.py
+++ b/pfrl/agents/reinforce.py
@@ -37,6 +37,7 @@ class REINFORCE(agent.AttributeSavingMixin, agent.Agent):
         max_grad_norm (float or None): Maximum L2 norm of the gradient used for
             gradient clipping. If set to None, the gradient is not clipped.
         logger (logging.Logger): Logger to be used.
+        optimize_hooks(list of callables): Hooks when optimizer.step() is called
     """
 
     saved_attributes = ("model", "optimizer")

--- a/pfrl/agents/reinforce.py
+++ b/pfrl/agents/reinforce.py
@@ -56,6 +56,7 @@ class REINFORCE(agent.AttributeSavingMixin, agent.Agent):
         recurrent=False,
         max_grad_norm=None,
         logger=None,
+        optimize_hooks=[],
     ):
 
         self.model = model
@@ -89,6 +90,7 @@ class REINFORCE(agent.AttributeSavingMixin, agent.Agent):
         self.log_prob_sequences = [[]]
         self.entropy_sequences = [[]]
         self.n_backward = 0
+        self.optimize_hooks = optimize_hooks
 
     def act(self, obs):
         if self.training:
@@ -207,6 +209,8 @@ class REINFORCE(agent.AttributeSavingMixin, agent.Agent):
             clip_l2_grad_norm_(self.model.parameters(), self.max_grad_norm)
         self.optimizer.step()
         self.n_backward = 0
+        for hook in self.optimize_hooks:
+            hook(self, self.optimizer)
 
     def update_with_accumulated_grad(self):
         assert self.n_backward == self.batchsize
@@ -214,6 +218,8 @@ class REINFORCE(agent.AttributeSavingMixin, agent.Agent):
             clip_l2_grad_norm_(self.model.parameters(), self.max_grad_norm)
         self.optimizer.step()
         self.n_backward = 0
+        for hook in self.optimize_hooks:
+            hook(self, self.optimizer)
 
     def get_statistics(self):
         return [

--- a/pfrl/agents/soft_actor_critic.py
+++ b/pfrl/agents/soft_actor_critic.py
@@ -81,6 +81,7 @@ class SoftActorCritic(AttributeSavingMixin, BatchAgent):
             is used.
         act_deterministically (bool): If set to True, choose most probable
             actions in the act method instead of sampling from distributions.
+        optimize_hooks(list of callables): Hooks when optimizer.step() is called
     """
 
     saved_attributes = (
@@ -120,7 +121,7 @@ class SoftActorCritic(AttributeSavingMixin, BatchAgent):
         entropy_target=None,
         temperature_optimizer_lr=None,
         act_deterministically=True,
-        optimizer_hooks=[],
+        optimize_hooks=[],
     ):
 
         self.policy = policy
@@ -192,7 +193,7 @@ class SoftActorCritic(AttributeSavingMixin, BatchAgent):
         self.q_func2_loss_record = collections.deque(maxlen=100)
         self.n_policy_updates = 0
 
-        self.optimie_hooks = optimizer_hooks
+        self.optimize_hooks = optimize_hooks
 
     @property
     def temperature(self):

--- a/pfrl/agents/td3.py
+++ b/pfrl/agents/td3.py
@@ -64,6 +64,7 @@ class TD3(AttributeSavingMixin, BatchAgent):
         target_policy_smoothing_func (callable): Callable that takes a batch of
             actions as input and outputs a noisy version of it. It is used for
             target policy smoothing when computing target Q-values.
+        optimize_hooks(list of callables): Hooks when optimizer.step() is called
     """
 
     saved_attributes = (

--- a/pfrl/agents/trpo.py
+++ b/pfrl/agents/trpo.py
@@ -145,6 +145,7 @@ class TRPO(agent.AttributeSavingMixin, agent.BatchAgent):
             of KL divergence between old and new policies.
         policy_step_size_stats_window (int): Window size used to compute
             statistics of step sizes of policy updates.
+        optimize_hooks(list of callables): Hooks when optimizer.step() is called
 
     Statistics:
         average_value: Average of value predictions on non-terminal states.

--- a/pfrl/experiments/hooks.py
+++ b/pfrl/experiments/hooks.py
@@ -24,6 +24,25 @@ class StepHook(object, metaclass=ABCMeta):
         raise NotImplementedError
 
 
+class OptimizeHook(object, metaclass=ABCMeta):
+    """Update hook function that will be called in training.
+
+    This class is for clarifying the interface required for update hook functions.
+    You don't need to inherit this class to define your own hooks. Any callable
+    that accepts (env, agent, step) as arguments can be used as a hook.
+    """
+
+    @abstractmethod
+    def __call__(self, agent, optim):
+        """Call the hook.
+
+        Args:
+            agent: Agent.
+            step: Current timestep.
+        """
+        raise NotImplementedError
+
+
 class LinearInterpolationHook(StepHook):
     """Hook that will set a linearly interpolated value.
 


### PR DESCRIPTION
In some cases, it'd be beneficial to have hooks in the trainer loop. PFRL already provides `step_hooks` and `global_step_hooks` in `train_agent` and `train_agent_async` respectively, but they are not for learners. In particular, the latter `global_step_hook` works in actors and there's no hook mechanism in learners.

This PR provides `optimize_hook` in agents under `pfrl.agents` package. Each agent takes `optimize_hooks`, which is a list of callable objects, as a parameter of their constructors. In the learner loop, the hooks are invoked just after `optimizer.step()` method is called. 


