### PR TITLE
Save and load a module trained with DataParallel or DistributedDataParallel 

### DIFF
--- a/pfrl/agent.py
+++ b/pfrl/agent.py
@@ -102,8 +102,10 @@ class AttributeSavingMixin(object):
                 ), "Avoid an infinite loop"
                 attr_value.__save(os.path.join(dirname, attr), ancestors)
             else:
-                if isinstance(attr_value, (torch.nn.parallel.DistributedDataParallel,
-                                           torch.nn.DataParallel)):
+                if isinstance(
+                    attr_value,
+                    (torch.nn.parallel.DistributedDataParallel, torch.nn.DataParallel),
+                ):
                     attr_value = attr_value.module
                 torch.save(
                     attr_value.state_dict(), os.path.join(dirname, "{}.pt".format(attr))
@@ -128,8 +130,10 @@ class AttributeSavingMixin(object):
                 ), "Avoid an infinite loop"
                 attr_value.load(os.path.join(dirname, attr))
             else:
-                if isinstance(attr_value, (torch.nn.parallel.DistributedDataParallel,
-                                           torch.nn.DataParallel)):
+                if isinstance(
+                    attr_value,
+                    (torch.nn.parallel.DistributedDataParallel, torch.nn.DataParallel),
+                ):
                     attr_value = attr_value.module
                 attr_value.load_state_dict(
                     torch.load(

--- a/pfrl/agent.py
+++ b/pfrl/agent.py
@@ -102,6 +102,9 @@ class AttributeSavingMixin(object):
                 ), "Avoid an infinite loop"
                 attr_value.__save(os.path.join(dirname, attr), ancestors)
             else:
+                if isinstance(attr_value, (torch.nn.parallel.DistributedDataParallel,
+                                           torch.nn.DataParallel)):
+                    attr_value = attr_value.module
                 torch.save(
                     attr_value.state_dict(), os.path.join(dirname, "{}.pt".format(attr))
                 )
@@ -125,6 +128,9 @@ class AttributeSavingMixin(object):
                 ), "Avoid an infinite loop"
                 attr_value.load(os.path.join(dirname, attr))
             else:
+                if isinstance(attr_value, (torch.nn.parallel.DistributedDataParallel,
+                                           torch.nn.DataParallel)):
+                    attr_value = attr_value.module
                 attr_value.load_state_dict(
                     torch.load(
                         os.path.join(dirname, "{}.pt".format(attr)), map_location

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -91,3 +91,36 @@ class TestAttributeSavingMixin(unittest.TestCase):
         # Otherwise it seems to raise OSError: [Errno 63] File name too long
         with self.assertRaises(AssertionError):
             parent1.save(dirname)
+
+    def test_with_data_parallel(self):
+        parent = Parent()
+        parent.link.param.detach().numpy()[:] = 1
+        parent.child.link.param.detach().numpy()[:] = 2
+        parent.link = torch.nn.DataParallel(parent.link)
+
+        # Save
+        dirname = tempfile.mkdtemp()
+        parent.save(dirname)
+        self.assertTrue(os.path.isdir(dirname))
+        self.assertTrue(os.path.isfile(os.path.join(dirname, "link.pt")))
+        self.assertTrue(os.path.isdir(os.path.join(dirname, "child")))
+        self.assertTrue(os.path.isfile(os.path.join(dirname, "child", "link.pt")))
+
+        # Load Parent without data parallel
+        parent = Parent()
+        self.assertEqual(int(parent.link.param.detach().numpy()), 0)
+        self.assertEqual(int(parent.child.link.param.detach().numpy()), 0)
+        parent.load(dirname)
+        self.assertEqual(int(parent.link.param.detach().numpy()), 1)
+        self.assertEqual(int(parent.child.link.param.detach().numpy()), 2)
+
+        # Load Parent with data parallel
+        parent = Parent()
+        parent.link = torch.nn.DataParallel(parent.link)
+        self.assertEqual(int(parent.link.module.param.detach().numpy()), 0)
+        self.assertEqual(int(parent.child.link.param.detach().numpy()), 0)
+        parent.load(dirname)
+        self.assertEqual(int(parent.link.module.param.detach().numpy()), 1)
+        self.assertEqual(int(parent.child.link.param.detach().numpy()), 2)
+
+

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -122,5 +122,3 @@ class TestAttributeSavingMixin(unittest.TestCase):
         parent.load(dirname)
         self.assertEqual(int(parent.link.module.param.detach().numpy()), 1)
         self.assertEqual(int(parent.child.link.param.detach().numpy()), 2)
-
-


### PR DESCRIPTION
This PR fixes save and load of agent to load a model trained with `DataParallel` or `DistributedDataParallel`.

After learning with  `DistributedDataParallel` and loading the model without using  `DistributedDataParallel`, the following error occurred
```
Traceback (most recent call last):
  File "./train_dqn_gym.py", line 268, in <module>
    main()
  File "./train_dqn_gym.py", line 194, in main
    agent.load(args.load)
  File "/home/shu/workspace/pfrl/packages/pfrl/pfrl/agent.py", line 113, in load
    self.__load(dirname, [])
  File "/home/shu/workspace/pfrl/packages/pfrl/pfrl/agent.py", line 132, in __load
    os.path.join(dirname, "{}.pt".format(attr)), map_location
  File "/home/shu/.pyenv/versions/pfrl/lib/python3.7/site-packages/torch/nn/modules/module.py", line 847, in load_state_dict
    self.__class__.__name__, "\n\t".join(error_msgs)))
RuntimeError: Error(s) in loading state_dict for FCStateQFunctionWithDiscreteAction:
	Missing key(s) in state_dict: "model.hidden_layers.0.weight", "model.hidden_layers.0.bias", "model.hidden_layers.1.weight", "model.hidden_layers.1.bias", "model.output.weight", "model.output.bias". 
	Unexpected key(s) in state_dict: "module.model.hidden_layers.0.weight", "module.model.hidden_layers.0.bias", "module.model.hidden_layers.1.weight", "module.model.hidden_layers.1.bias", "module.model.output.weight", "module.model.output.bias". 

```

To solve this error, I made the PR.