### PR TITLE
Enable auto review assignment for PRs from forks

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -1,6 +1,6 @@
 name: 'Auto Assign'
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   add-reviews:


### PR DESCRIPTION
See https://github.com/kentaro-m/auto-assign-action/issues/29

Without this change, `auto-assign-action` fails to assign reviewers to PRs from forked repositories. Confirmed on: https://github.com/pfnet/pfrl/pull/54

With this change, it can assign reviewers to such PRs. Confirmed on: https://github.com/pfnet/pfrl/pull/61