### PR TITLE
Replace nn.functional.tanh with torch.tanh

### DIFF
--- a/pfrl/agents/trpo.py
+++ b/pfrl/agents/trpo.py
@@ -119,7 +119,7 @@ class TRPO(agent.AttributeSavingMixin, agent.BatchAgent):
         gamma (float): Discount factor [0, 1]
         lambd (float): Lambda-return factor [0, 1]
         phi (callable): Feature extractor function
-        entropy_coef (float): Weight coefficient for entropoy bonus [0, inf)
+        entropy_coef (float): Weight coefficient for entropy bonus [0, inf)
         update_interval (int): Interval steps of TRPO iterations. Every after
             this amount of steps, this agent updates the policy and the value
             function using data from these steps.

--- a/pfrl/functions/bound_by_tanh.py
+++ b/pfrl/functions/bound_by_tanh.py
@@ -20,4 +20,4 @@ def bound_by_tanh(x, low, high):
     high = torch.as_tensor(high, dtype=x.dtype, device=x.device)
     scale = (high - low) / 2
     loc = (high + low) / 2
-    return nn.functional.tanh(x) * scale + loc
+    return torch.tanh(x) * scale + loc

--- a/pfrl/functions/bound_by_tanh.py
+++ b/pfrl/functions/bound_by_tanh.py
@@ -1,5 +1,4 @@
 import torch
-from torch import nn
 
 
 def bound_by_tanh(x, low, high):


### PR DESCRIPTION
When I run PFRL code, I get the warning:
```
/Users/prabhat/miniconda3/envs/pfrl/lib/python3.7/site-packages/torch/nn/functional.py:1558: UserWarning: nn.functional.tanh is deprecated. Use torch.tanh instead.
  warnings.warn("nn.functional.tanh is deprecated. Use torch.tanh instead.")
```
This is corroborated by https://discuss.pytorch.org/t/torch-tanh-vs-torch-nn-functional-tanh/15897.