### PR TITLE
Activate auto assign only when a PR is opened

### DIFF
--- a/.github/workflows/auto_assign.yml
+++ b/.github/workflows/auto_assign.yml
@@ -1,6 +1,8 @@
 name: 'Auto Assign'
 
-on: pull_request_target
+on:
+  pull_request_target:
+    types: [opened]
 
 jobs:
   add-reviews:


### PR DESCRIPTION
Activate auto assign only when a PR is opened.

> By default, a workflow only runs when a pull_request_target's activity type is opened, synchronize, or reopened

https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target