### PR TITLE
Updates the supported Python version in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PFRL is a deep reinforcement learning library that implements various state-of-t
 
 ## Installation
 
-PFRL is tested with 3.5.1+. For other requirements, see [requirements.txt](requirements.txt).
+PFRL is tested with 3.6. For other requirements, see [requirements.txt](requirements.txt).
 
 PFRL can be installed via PyPI:
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PFRL is a deep reinforcement learning library that implements various state-of-t
 
 ## Installation
 
-PFRL is tested with 3.6. For other requirements, see [requirements.txt](requirements.txt).
+PFRL is tested with 3.6+. For other requirements, see [requirements.txt](requirements.txt).
 
 PFRL can be installed via PyPI:
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PFRL is a deep reinforcement learning library that implements various state-of-t
 
 ## Installation
 
-PFRL is tested with 3.6+. For other requirements, see [requirements.txt](requirements.txt).
+PFRL is tested with 3.7.7+. For other requirements, see [requirements.txt](requirements.txt).
 
 PFRL can be installed via PyPI:
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PFRL is a deep reinforcement learning library that implements various state-of-t
 
 ## Installation
 
-PFRL is tested with 3.7.7+. For other requirements, see [requirements.txt](requirements.txt).
+PFRL is tested with Python 3.7.7. For other requirements, see [requirements.txt](requirements.txt).
 
 PFRL can be installed via PyPI:
 ```


### PR DESCRIPTION
Our internal job scheduler was giving an error on `import pfrl` for Python version 3.5.2. 

I just created a new conda environment with Python 3.5.6, and did `pip install -e .` with my master branch (up to date with upstream pfnet/pfrl repo), and ran the following:

```
(pfrl_test) Prabhats-MacBook-Pro:pfrl prabhat$ python
Python 3.5.6 |Anaconda, Inc.| (default, Aug 26 2018, 16:30:03) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pfrl
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/prabhat/pfn/pfrl/pfrl/__init__.py", line 3, in <module>
    from pfrl import agents  # NOQA
  File "/Users/prabhat/pfn/pfrl/pfrl/agents/__init__.py", line 4, in <module>
    from pfrl.agents.al import AL  # NOQA
  File "/Users/prabhat/pfn/pfrl/pfrl/agents/al.py", line 2, in <module>
    from pfrl.agents import dqn
  File "/Users/prabhat/pfn/pfrl/pfrl/agents/dqn.py", line 229
    update_func: Callable[..., None]
               ^
SyntaxError: invalid syntax
```
Note this:
https://stackoverflow.com/questions/51789120/type-hints-syntax-error-on-python-3-5

Line 229 of dqn.py (https://github.com/pfnet/pfrl/blob/master/pfrl/agents/dqn.py#L229) appears to be a variable annotation, which is consistent with this Python 3.6 hypothesis.

I did the same conda check for Python 3.6 and `import pfrl` gave no error.

I looked at the CI, and it seems pretty clear we're testing with Python 3.6: https://ci.preferred.jp/pfrl.cpu/62645/. E.g. just ctrl + f "3.6" and "3.5" and it becomes apparent.