### PR TITLE
Eval stats collector

### DIFF
--- a/pfrl/experiments/evaluator.py
+++ b/pfrl/experiments/evaluator.py
@@ -340,7 +340,7 @@ def write_header(outdir, agent, env):
     )
     with open(os.path.join(outdir, "scores.txt"), "w") as f:
         custom_columns = tuple(t[0] for t in agent.get_statistics())
-        env_get_stats = env.getattr("get_statistics", lambda : [])
+        env_get_stats = getattr(env, "get_statistics", lambda : [])
         assert callable(env_get_stats)
         custom_env_columns = tuple(t[0] for t in env_get_stats())
         column_names = basic_columns + custom_columns + custom_env_columns
@@ -398,8 +398,8 @@ class Evaluator(object):
         self.prev_eval_t = self.step_offset - self.step_offset % self.eval_interval
         self.save_best_so_far_agent = save_best_so_far_agent
         self.logger = logger or logging.getLogger(__name__)
-        self.env_get_stats = self.env.getattr("get_statistics", lambda : [])
-        self.env_clear_stats = self.env.getattr("clear_statistics", lambda : None)
+        self.env_get_stats = getattr(self.env, "get_statistics", lambda : [])
+        self.env_clear_stats = getattr(self.env, "clear_statistics", lambda : None)
         assert callable(self.env_get_stats)
         assert callable(self.env_clear_stats)
 
@@ -520,8 +520,8 @@ class AsyncEvaluator(object):
         return v
 
     def evaluate_and_update_max_score(self, t, episodes, env, agent):
-        env_get_stats = env.getattr("get_statistics", lambda : [])
-        env_clear_stats = env.getattr("clear_statistics", lambda : None)
+        env_get_stats = getattr(env, "get_statistics", lambda : [])
+        env_clear_stats = getattr(env, "clear_statistics", lambda : None)
         assert callable(env_get_stats)
         assert callable(env_clear_stats)
         env_clear_stats()

--- a/pfrl/experiments/evaluator.py
+++ b/pfrl/experiments/evaluator.py
@@ -326,6 +326,7 @@ def save_agent(agent, t, outdir, logger, suffix=""):
     agent.save(dirname)
     logger.info("Saved the agent to %s", dirname)
 
+
 def write_header(outdir, agent, env):
     # Columns that describe information about an experiment.
     basic_columns = (
@@ -340,7 +341,7 @@ def write_header(outdir, agent, env):
     )
     with open(os.path.join(outdir, "scores.txt"), "w") as f:
         custom_columns = tuple(t[0] for t in agent.get_statistics())
-        env_get_stats = getattr(env, "get_statistics", lambda : [])
+        env_get_stats = getattr(env, "get_statistics", lambda: [])
         assert callable(env_get_stats)
         custom_env_columns = tuple(t[0] for t in env_get_stats())
         column_names = basic_columns + custom_columns + custom_env_columns
@@ -398,8 +399,8 @@ class Evaluator(object):
         self.prev_eval_t = self.step_offset - self.step_offset % self.eval_interval
         self.save_best_so_far_agent = save_best_so_far_agent
         self.logger = logger or logging.getLogger(__name__)
-        self.env_get_stats = getattr(self.env, "get_statistics", lambda : [])
-        self.env_clear_stats = getattr(self.env, "clear_statistics", lambda : None)
+        self.env_get_stats = getattr(self.env, "get_statistics", lambda: [])
+        self.env_clear_stats = getattr(self.env, "clear_statistics", lambda: None)
         assert callable(self.env_get_stats)
         assert callable(self.env_clear_stats)
 
@@ -426,15 +427,19 @@ class Evaluator(object):
         custom_env_values = tuple(tup[1] for tup in env_stats)
         mean = eval_stats["mean"]
         values = (
-            t,
-            episodes,
-            elapsed,
-            mean,
-            eval_stats["median"],
-            eval_stats["stdev"],
-            eval_stats["max"],
-            eval_stats["min"],
-        ) + custom_values + custom_env_values
+            (
+                t,
+                episodes,
+                elapsed,
+                mean,
+                eval_stats["median"],
+                eval_stats["stdev"],
+                eval_stats["max"],
+                eval_stats["min"],
+            )
+            + custom_values
+            + custom_env_values
+        )
         record_stats(self.outdir, values)
 
         if self.use_tensorboard:
@@ -520,8 +525,8 @@ class AsyncEvaluator(object):
         return v
 
     def evaluate_and_update_max_score(self, t, episodes, env, agent):
-        env_get_stats = getattr(env, "get_statistics", lambda : [])
-        env_clear_stats = getattr(env, "clear_statistics", lambda : None)
+        env_get_stats = getattr(env, "get_statistics", lambda: [])
+        env_clear_stats = getattr(env, "clear_statistics", lambda: None)
         assert callable(env_get_stats)
         assert callable(env_clear_stats)
         env_clear_stats()
@@ -540,15 +545,19 @@ class AsyncEvaluator(object):
         custom_env_values = tuple(tup[1] for tup in env_stats)
         mean = eval_stats["mean"]
         values = (
-            t,
-            episodes,
-            elapsed,
-            mean,
-            eval_stats["median"],
-            eval_stats["stdev"],
-            eval_stats["max"],
-            eval_stats["min"],
-        ) + custom_values + custom_env_values
+            (
+                t,
+                episodes,
+                elapsed,
+                mean,
+                eval_stats["median"],
+                eval_stats["stdev"],
+                eval_stats["max"],
+                eval_stats["min"],
+            )
+            + custom_values
+            + custom_env_values
+        )
         record_stats(self.outdir, values)
 
         if self.use_tensorboard:

--- a/pfrl/experiments/evaluator.py
+++ b/pfrl/experiments/evaluator.py
@@ -404,12 +404,13 @@ class Evaluator(object):
         assert callable(self.env_clear_stats)
 
         # Write a header line first
-        write_header(self.outdir, self.agent)
+        write_header(self.outdir, self.agent, self.env)
 
         if use_tensorboard:
             self.tb_writer = create_tb_writer(outdir)
 
     def evaluate_and_update_max_score(self, t, episodes):
+        self.env_clear_stats()
         eval_stats = eval_performance(
             self.env,
             self.agent,
@@ -422,7 +423,6 @@ class Evaluator(object):
         agent_stats = self.agent.get_statistics()
         custom_values = tuple(tup[1] for tup in agent_stats)
         env_stats = self.env_get_stats()
-        self.env_clear_stats()
         custom_env_values = tuple(tup[1] for tup in env_stats)
         mean = eval_stats["mean"]
         values = (
@@ -520,6 +520,7 @@ class AsyncEvaluator(object):
         return v
 
     def evaluate_and_update_max_score(self, t, episodes, env, agent):
+
         eval_stats = eval_performance(
             env,
             agent,
@@ -566,7 +567,7 @@ class AsyncEvaluator(object):
         if necessary:
             with self.wrote_header.get_lock():
                 if not self.wrote_header.value:
-                    write_header(self.outdir, agent)
+                    write_header(self.outdir, agent, env)
                     self.wrote_header.value = True
             return self.evaluate_and_update_max_score(t, episodes, env, agent)
         return None

--- a/tests/experiments_tests/test_evaluator.py
+++ b/tests/experiments_tests/test_evaluator.py
@@ -24,6 +24,7 @@ def test_evaluator_evaluate_if_necessary(save_best_so_far_agent, n_steps, n_epis
     env = mock.Mock()
     env.reset.return_value = "obs"
     env.step.return_value = ("obs", 0, True, {})
+    env.get_statistics.return_value = []
 
     either_none = (n_steps is None) != (n_episodes is None)
     if not either_none:
@@ -101,6 +102,7 @@ def test_async_evaluator_evaluate_if_necessary(save_best_so_far_agent, n_episode
     env = mock.Mock()
     env.reset.return_value = "obs"
     env.step.return_value = ("obs", 0, True, {})
+    env.get_statistics.return_value = []
 
     agent_evaluator = evaluator.AsyncEvaluator(
         n_steps=None,


### PR DESCRIPTION
We currently collect basic performance statistics as well as agent statistics. This PR allows environment statistics to be collected. This gives a lot of flexibility. For example, if you have a binary success task such as grasping, your environment could give a "success" statistic, in addition to the reward. If you have a finance domain, your environment could track "profit" separate from the reward function.

The environment optionally implements two functions: `get_statistics` and `clear_statistics`. If these functions are not implemented, then the evaluator works as it did before (i.e. this PR is backwards compatible). 

- `get_statistics`: Returns the environment statistics. Defaults to returning an empty list if the environment doesn't implement it.
- `clear_statistics`: Clears the statistics. This is called before evaluation so that `get_statistics` only returns statistics collected during evaluation. By default does nothing if `clear_statistics` isn't implemented by the environment.