### PR TITLE
Adopt isort to format import sentences

### DIFF
--- a/.pfnci/lint.sh
+++ b/.pfnci/lint.sh
@@ -3,9 +3,10 @@
 set -eux
 
 # Use latest black to apply https://github.com/psf/black/issues/1288
-pip3 install git+git://github.com/psf/black.git@88d12f88a97e5e4c8fd0d245df0a311e932fd1e1 flake8 mypy
+pip3 install git+git://github.com/psf/black.git@88d12f88a97e5e4c8fd0d245df0a311e932fd1e1 flake8 mypy isort
 
 black --diff --check pfrl tests examples
+isort --diff --check pfrl tests examples
 flake8 pfrl tests examples
 mypy pfrl
 # mypy does not search child directories unless there is __init__.py

--- a/examples/atari/reproduction/a3c/train_a3c.py
+++ b/examples/atari/reproduction/a3c/train_a3c.py
@@ -8,12 +8,10 @@ import numpy as np
 from torch import nn
 
 import pfrl
+from pfrl import experiments, utils
 from pfrl.agents import a3c
-from pfrl import experiments
-from pfrl import utils
-from pfrl.policies import SoftmaxCategoricalHead
 from pfrl.optimizers import SharedRMSpropEpsInsideSqrt
-
+from pfrl.policies import SoftmaxCategoricalHead
 from pfrl.wrappers import atari_wrappers
 
 

--- a/examples/atari/reproduction/dqn/train_dqn.py
+++ b/examples/atari/reproduction/dqn/train_dqn.py
@@ -1,21 +1,17 @@
 import argparse
+import json
 import os
 
-import torch.nn as nn
 import numpy as np
+import torch.nn as nn
 
 import pfrl
-from pfrl.q_functions import DiscreteActionValueHead
-from pfrl import agents
-from pfrl import experiments
-from pfrl import explorers
+from pfrl import agents, experiments, explorers
 from pfrl import nn as pnn
-from pfrl import utils
-from pfrl import replay_buffers
-
-from pfrl.wrappers import atari_wrappers
+from pfrl import replay_buffers, utils
 from pfrl.initializers import init_chainer_default
-import json
+from pfrl.q_functions import DiscreteActionValueHead
+from pfrl.wrappers import atari_wrappers
 
 
 def main():

--- a/examples/atari/reproduction/iqn/train_iqn.py
+++ b/examples/atari/reproduction/iqn/train_iqn.py
@@ -7,10 +7,7 @@ import torch
 from torch import nn
 
 import pfrl
-from pfrl import experiments
-from pfrl import explorers
-from pfrl import utils
-from pfrl import replay_buffers
+from pfrl import experiments, explorers, replay_buffers, utils
 from pfrl.wrappers import atari_wrappers
 
 

--- a/examples/atari/reproduction/rainbow/train_rainbow.py
+++ b/examples/atari/reproduction/rainbow/train_rainbow.py
@@ -2,17 +2,14 @@ import argparse
 import json
 import os
 
-import torch
 import numpy as np
+import torch
 
 import pfrl
-from pfrl import agents
-from pfrl import experiments
-from pfrl import explorers
+from pfrl import agents, experiments, explorers
 from pfrl import nn as pnn
-from pfrl import utils
+from pfrl import replay_buffers, utils
 from pfrl.q_functions import DistributionalDuelingDQN
-from pfrl import replay_buffers
 from pfrl.wrappers import atari_wrappers
 
 

--- a/examples/atari/train_a2c_ale.py
+++ b/examples/atari/train_a2c_ale.py
@@ -6,9 +6,8 @@ import numpy as np
 from torch import nn
 
 import pfrl
+from pfrl import experiments, utils
 from pfrl.agents import a2c
-from pfrl import experiments
-from pfrl import utils
 from pfrl.policies import SoftmaxCategoricalHead
 from pfrl.wrappers import atari_wrappers
 

--- a/examples/atari/train_acer_ale.py
+++ b/examples/atari/train_acer_ale.py
@@ -10,13 +10,11 @@ import numpy as np
 from torch import nn
 
 import pfrl
+from pfrl import experiments, utils
 from pfrl.agents import acer
-from pfrl import experiments
-from pfrl import utils
-from pfrl.replay_buffers import EpisodicReplayBuffer
 from pfrl.policies import SoftmaxCategoricalHead
 from pfrl.q_functions import DiscreteActionValueHead
-
+from pfrl.replay_buffers import EpisodicReplayBuffer
 from pfrl.wrappers import atari_wrappers
 
 

--- a/examples/atari/train_categorical_dqn_ale.py
+++ b/examples/atari/train_categorical_dqn_ale.py
@@ -1,14 +1,10 @@
 import argparse
 
-import torch
 import numpy as np
+import torch
 
 import pfrl
-from pfrl import experiments
-from pfrl import explorers
-from pfrl import utils
-from pfrl import replay_buffers
-
+from pfrl import experiments, explorers, replay_buffers, utils
 from pfrl.wrappers import atari_wrappers
 
 

--- a/examples/atari/train_dqn_ale.py
+++ b/examples/atari/train_dqn_ale.py
@@ -1,21 +1,16 @@
 import argparse
 
+import numpy as np
 import torch
 import torch.nn as nn
-import numpy as np
 
 import pfrl
-from pfrl.q_functions import DiscreteActionValueHead
-from pfrl import agents
-from pfrl import experiments
-from pfrl import explorers
+from pfrl import agents, experiments, explorers
 from pfrl import nn as pnn
-from pfrl import utils
-from pfrl.q_functions import DuelingDQN
-from pfrl import replay_buffers
-
-from pfrl.wrappers import atari_wrappers
+from pfrl import replay_buffers, utils
 from pfrl.initializers import init_chainer_default
+from pfrl.q_functions import DiscreteActionValueHead, DuelingDQN
+from pfrl.wrappers import atari_wrappers
 
 
 class SingleSharedBias(nn.Module):

--- a/examples/atari/train_dqn_batch_ale.py
+++ b/examples/atari/train_dqn_batch_ale.py
@@ -1,23 +1,18 @@
 import argparse
 import functools
 
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.optim as optim
-import numpy as np
 
 import pfrl
-from pfrl import agents
-from pfrl import experiments
-from pfrl import explorers
+from pfrl import agents, experiments, explorers
 from pfrl import nn as pnn
-from pfrl import utils
-from pfrl.q_functions import DiscreteActionValueHead
-from pfrl.q_functions import DuelingDQN
-from pfrl import replay_buffers
-
-from pfrl.wrappers import atari_wrappers
+from pfrl import replay_buffers, utils
 from pfrl.initializers import init_chainer_default
+from pfrl.q_functions import DiscreteActionValueHead, DuelingDQN
+from pfrl.wrappers import atari_wrappers
 
 
 class SingleSharedBias(nn.Module):

--- a/examples/atari/train_drqn_ale.py
+++ b/examples/atari/train_drqn_ale.py
@@ -18,12 +18,8 @@ import torch
 from torch import nn
 
 import pfrl
-from pfrl import experiments
-from pfrl import explorers
-from pfrl import utils
-from pfrl import replay_buffers
+from pfrl import experiments, explorers, replay_buffers, utils
 from pfrl.q_functions import DiscreteActionValueHead
-
 from pfrl.wrappers import atari_wrappers
 
 

--- a/examples/atari/train_ppo_ale.py
+++ b/examples/atari/train_ppo_ale.py
@@ -15,11 +15,10 @@ import torch
 from torch import nn
 
 import pfrl
+from pfrl import experiments, utils
 from pfrl.agents import PPO
-from pfrl import experiments
-from pfrl import utils
-from pfrl.wrappers import atari_wrappers
 from pfrl.policies import SoftmaxCategoricalHead
+from pfrl.wrappers import atari_wrappers
 
 
 def main():

--- a/examples/atlas/train_soft_actor_critic_atlas.py
+++ b/examples/atlas/train_soft_actor_critic_atlas.py
@@ -8,14 +8,11 @@ import gym
 import gym.wrappers
 import numpy as np
 import torch
-from torch import nn
-from torch import distributions
+from torch import distributions, nn
 
 import pfrl
-from pfrl import experiments
+from pfrl import experiments, replay_buffers, utils
 from pfrl.nn.lmbda import Lambda
-from pfrl import utils
-from pfrl import replay_buffers
 
 
 def make_env(args, seed, test):

--- a/examples/grasping/train_dqn_batch_grasping.py
+++ b/examples/grasping/train_dqn_batch_grasping.py
@@ -9,11 +9,8 @@ import torch
 from torch import nn
 
 import pfrl
+from pfrl import experiments, explorers, replay_buffers, utils
 from pfrl.q_functions import DiscreteActionValueHead
-from pfrl import experiments
-from pfrl import explorers
-from pfrl import utils
-from pfrl import replay_buffers
 
 
 class CastAction(gym.ActionWrapper):
@@ -243,9 +240,9 @@ def main():
     max_episode_steps = 8
 
     def make_env(idx, test):
-        from pybullet_envs.bullet.kuka_diverse_object_gym_env import (
+        from pybullet_envs.bullet.kuka_diverse_object_gym_env import (  # NOQA
             KukaDiverseObjectEnv,
-        )  # NOQA
+        )
 
         # Use different random seeds for train and test envs
         process_seed = int(process_seeds[idx])

--- a/examples/gym/train_categorical_dqn_gym.py
+++ b/examples/gym/train_categorical_dqn_gym.py
@@ -10,15 +10,11 @@ To solve CartPole-v0, run:
 import argparse
 import sys
 
-import torch
 import gym
+import torch
 
 import pfrl
-from pfrl import experiments
-from pfrl import explorers
-from pfrl import utils
-from pfrl import q_functions
-from pfrl import replay_buffers
+from pfrl import experiments, explorers, q_functions, replay_buffers, utils
 
 
 def main():

--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -12,22 +12,19 @@ To solve Pendulum-v0, run:
 """
 
 import argparse
-import sys
 import os
+import sys
 
-import torch.optim as optim
 import gym
-from gym import spaces
 import numpy as np
+import torch.optim as optim
+from gym import spaces
 
 import pfrl
-from pfrl.agents.dqn import DQN
-from pfrl import experiments
-from pfrl import explorers
+from pfrl import experiments, explorers
 from pfrl import nn as pnn
-from pfrl import utils
-from pfrl import q_functions
-from pfrl import replay_buffers
+from pfrl import q_functions, replay_buffers, utils
+from pfrl.agents.dqn import DQN
 
 
 def main():

--- a/examples/gym/train_reinforce_gym.py
+++ b/examples/gym/train_reinforce_gym.py
@@ -17,10 +17,8 @@ import torch
 from torch import nn
 
 import pfrl
-from pfrl import experiments
-from pfrl import utils
-from pfrl.policies import SoftmaxCategoricalHead
-from pfrl.policies import GaussianHeadWithFixedCovariance
+from pfrl import experiments, utils
+from pfrl.policies import GaussianHeadWithFixedCovariance, SoftmaxCategoricalHead
 
 
 def main():

--- a/examples/mujoco/reproduction/ddpg/train_ddpg.py
+++ b/examples/mujoco/reproduction/ddpg/train_ddpg.py
@@ -15,13 +15,9 @@ import torch
 from torch import nn
 
 import pfrl
+from pfrl import experiments, explorers, replay_buffers, utils
 from pfrl.agents.ddpg import DDPG
-from pfrl import experiments
-from pfrl import explorers
-from pfrl import utils
-from pfrl import replay_buffers
-from pfrl.nn import ConcatObsAndAction
-from pfrl.nn import BoundByTanh
+from pfrl.nn import BoundByTanh, ConcatObsAndAction
 from pfrl.policies import DeterministicHead
 
 

--- a/examples/mujoco/reproduction/ppo/train_ppo.py
+++ b/examples/mujoco/reproduction/ppo/train_ppo.py
@@ -13,9 +13,8 @@ import torch
 from torch import nn
 
 import pfrl
+from pfrl import experiments, utils
 from pfrl.agents import PPO
-from pfrl import experiments
-from pfrl import utils
 
 
 def main():

--- a/examples/mujoco/reproduction/soft_actor_critic/train_soft_actor_critic.py
+++ b/examples/mujoco/reproduction/soft_actor_critic/train_soft_actor_critic.py
@@ -4,23 +4,20 @@ This script follows the settings of https://arxiv.org/abs/1812.05905 as much
 as possible.
 """
 import argparse
-from distutils.version import LooseVersion
 import functools
 import logging
 import sys
+from distutils.version import LooseVersion
 
-import torch
-from torch import nn
-from torch import distributions
 import gym
 import gym.wrappers
 import numpy as np
+import torch
+from torch import distributions, nn
 
 import pfrl
-from pfrl import experiments
+from pfrl import experiments, replay_buffers, utils
 from pfrl.nn.lmbda import Lambda
-from pfrl import utils
-from pfrl import replay_buffers
 
 
 def main():

--- a/examples/mujoco/reproduction/td3/train_td3.py
+++ b/examples/mujoco/reproduction/td3/train_td3.py
@@ -15,10 +15,7 @@ import torch
 from torch import nn
 
 import pfrl
-from pfrl import experiments
-from pfrl import explorers
-from pfrl import utils
-from pfrl import replay_buffers
+from pfrl import experiments, explorers, replay_buffers, utils
 
 
 def main():

--- a/examples/slimevolley/train_rainbow.py
+++ b/examples/slimevolley/train_rainbow.py
@@ -2,17 +2,14 @@ import argparse
 
 import gym
 import gym.spaces
+import numpy as np
 import torch
 from torch import nn
-import numpy as np
 
 import pfrl
-from pfrl import agents
-from pfrl import experiments
-from pfrl import explorers
+from pfrl import agents, experiments, explorers
 from pfrl import nn as pnn
-from pfrl import utils
-from pfrl import replay_buffers
+from pfrl import replay_buffers, utils
 
 
 class MultiBinaryAsDiscreteAction(gym.ActionWrapper):

--- a/pfrl/__init__.py
+++ b/pfrl/__init__.py
@@ -9,7 +9,6 @@ from pfrl import explorer  # NOQA
 from pfrl import explorers  # NOQA
 from pfrl import functions  # NOQA
 from pfrl import nn  # NOQA
-from pfrl import utils  # NOQA
 from pfrl import optimizers  # NOQA
 from pfrl import policies  # NOQA
 from pfrl import policy  # NOQA
@@ -17,4 +16,5 @@ from pfrl import q_function  # NOQA
 from pfrl import q_functions  # NOQA
 from pfrl import replay_buffer  # NOQA
 from pfrl import replay_buffers  # NOQA
+from pfrl import utils  # NOQA
 from pfrl import wrappers  # NOQA

--- a/pfrl/action_value.py
+++ b/pfrl/action_value.py
@@ -1,7 +1,5 @@
-from abc import ABCMeta
-from abc import abstractmethod
-from abc import abstractproperty
 import warnings
+from abc import ABCMeta, abstractmethod, abstractproperty
 
 import torch
 import torch.nn.functional as F

--- a/pfrl/agent.py
+++ b/pfrl/agent.py
@@ -1,13 +1,7 @@
-from abc import ABCMeta
-from abc import abstractmethod
-from abc import abstractproperty
 import contextlib
 import os
-from typing import Any
-from typing import List
-from typing import Optional
-from typing import Sequence
-from typing import Tuple
+from abc import ABCMeta, abstractmethod, abstractproperty
+from typing import Any, List, Optional, Sequence, Tuple
 
 import torch
 

--- a/pfrl/agents/__init__.py
+++ b/pfrl/agents/__init__.py
@@ -14,6 +14,6 @@ from pfrl.agents.pal import PAL  # NOQA
 from pfrl.agents.ppo import PPO  # NOQA
 from pfrl.agents.reinforce import REINFORCE  # NOQA
 from pfrl.agents.soft_actor_critic import SoftActorCritic  # NOQA
+from pfrl.agents.state_q_function_actor import StateQFunctionActor  # NOQA
 from pfrl.agents.td3 import TD3  # NOQA
 from pfrl.agents.trpo import TRPO  # NOQA
-from pfrl.agents.state_q_function_actor import StateQFunctionActor  # NOQA

--- a/pfrl/agents/a2c.py
+++ b/pfrl/agents/a2c.py
@@ -1,12 +1,12 @@
-from logging import getLogger
 import warnings
+from logging import getLogger
 
 import torch
 
 from pfrl import agent
+from pfrl.utils import clip_l2_grad_norm_
 from pfrl.utils.batch_states import batch_states
 from pfrl.utils.mode_of_distribution import mode_of_distribution
-from pfrl.utils import clip_l2_grad_norm_
 
 logger = getLogger(__name__)
 

--- a/pfrl/agents/a3c.py
+++ b/pfrl/agents/a3c.py
@@ -6,12 +6,10 @@ import torch.nn.functional as F
 
 import pfrl
 from pfrl import agent
+from pfrl.utils import clip_l2_grad_norm_, copy_param
 from pfrl.utils.batch_states import batch_states
-from pfrl.utils import copy_param
 from pfrl.utils.mode_of_distribution import mode_of_distribution
-from pfrl.utils.recurrent import one_step_forward
-from pfrl.utils.recurrent import pack_and_forward
-from pfrl.utils import clip_l2_grad_norm_
+from pfrl.utils.recurrent import one_step_forward, pack_and_forward
 
 logger = getLogger(__name__)
 

--- a/pfrl/agents/acer.py
+++ b/pfrl/agents/acer.py
@@ -5,14 +5,12 @@ import numpy as np
 import torch
 from torch import nn
 
-from pfrl.action_value import SingleActionValue
 from pfrl import agent
+from pfrl.action_value import SingleActionValue
+from pfrl.utils import clip_l2_grad_norm_, copy_param
 from pfrl.utils.batch_states import batch_states
-from pfrl.utils import copy_param
 from pfrl.utils.mode_of_distribution import mode_of_distribution
-from pfrl.utils.recurrent import one_step_forward
-from pfrl.utils.recurrent import detach_recurrent_state
-from pfrl.utils import clip_l2_grad_norm_
+from pfrl.utils.recurrent import detach_recurrent_state, one_step_forward
 
 
 def compute_importance(pi, mu, x):

--- a/pfrl/agents/al.py
+++ b/pfrl/agents/al.py
@@ -1,4 +1,5 @@
 import torch
+
 from pfrl.agents import dqn
 from pfrl.utils.recurrent import pack_and_forward
 

--- a/pfrl/agents/ddpg.py
+++ b/pfrl/agents/ddpg.py
@@ -2,18 +2,16 @@ import collections
 import copy
 from logging import getLogger
 
+import numpy as np
 import torch
 from torch import nn
 from torch.nn import functional as F
-import numpy as np
 
-from pfrl.agent import AttributeSavingMixin
-from pfrl.agent import BatchAgent
+from pfrl.agent import AttributeSavingMixin, BatchAgent
+from pfrl.replay_buffer import ReplayUpdater, batch_experiences
 from pfrl.utils.batch_states import batch_states
 from pfrl.utils.contexts import evaluating
 from pfrl.utils.copy_param import synchronize_parameters
-from pfrl.replay_buffer import batch_experiences
-from pfrl.replay_buffer import ReplayUpdater
 
 
 def _mean_or_nan(xs):

--- a/pfrl/agents/dpp.py
+++ b/pfrl/agents/dpp.py
@@ -1,5 +1,4 @@
-from abc import ABCMeta
-from abc import abstractmethod
+from abc import ABCMeta, abstractmethod
 
 import torch
 

--- a/pfrl/agents/dqn.py
+++ b/pfrl/agents/dqn.py
@@ -1,39 +1,37 @@
-import copy
 import collections
-import time
+import copy
 import ctypes
 import multiprocessing as mp
 import multiprocessing.synchronize
-from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Sequence
-from typing import Tuple
-from logging import Logger
-from logging import getLogger
+import time
+from logging import Logger, getLogger
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
+import numpy as np
 import torch
 import torch.nn.functional as F
-import numpy as np
 
 import pfrl
 from pfrl import agent
 from pfrl.action_value import ActionValue
 from pfrl.explorer import Explorer
+from pfrl.replay_buffer import (
+    AbstractEpisodicReplayBuffer,
+    ReplayUpdater,
+    batch_experiences,
+    batch_recurrent_experiences,
+)
+from pfrl.replay_buffers import PrioritizedReplayBuffer
 from pfrl.utils.batch_states import batch_states
 from pfrl.utils.contexts import evaluating
 from pfrl.utils.copy_param import synchronize_parameters
-from pfrl.replay_buffer import AbstractEpisodicReplayBuffer, batch_experiences
-from pfrl.replay_buffer import batch_recurrent_experiences
-from pfrl.replay_buffer import ReplayUpdater
-from pfrl.replay_buffers import PrioritizedReplayBuffer
-from pfrl.utils.recurrent import get_recurrent_state_at
-from pfrl.utils.recurrent import mask_recurrent_state_at
-from pfrl.utils.recurrent import one_step_forward
-from pfrl.utils.recurrent import pack_and_forward
-from pfrl.utils.recurrent import recurrent_state_as_numpy
+from pfrl.utils.recurrent import (
+    get_recurrent_state_at,
+    mask_recurrent_state_at,
+    one_step_forward,
+    pack_and_forward,
+    recurrent_state_as_numpy,
+)
 
 
 def _mean_or_nan(xs: Sequence[float]) -> float:

--- a/pfrl/agents/iqn.py
+++ b/pfrl/agents/iqn.py
@@ -5,8 +5,7 @@ from torch import nn
 from pfrl.action_value import QuantileDiscreteActionValue
 from pfrl.agents import dqn
 from pfrl.nn import Recurrent
-from pfrl.utils.recurrent import one_step_forward
-from pfrl.utils.recurrent import pack_and_forward
+from pfrl.utils.recurrent import one_step_forward, pack_and_forward
 
 
 def cosine_basis_functions(x, n_basis_functions=64):

--- a/pfrl/agents/ppo.py
+++ b/pfrl/agents/ppo.py
@@ -10,12 +10,14 @@ import pfrl
 from pfrl import agent
 from pfrl.utils.batch_states import batch_states
 from pfrl.utils.mode_of_distribution import mode_of_distribution
-from pfrl.utils.recurrent import get_recurrent_state_at
-from pfrl.utils.recurrent import mask_recurrent_state_at
-from pfrl.utils.recurrent import concatenate_recurrent_states
-from pfrl.utils.recurrent import one_step_forward
-from pfrl.utils.recurrent import flatten_sequences_time_first
-from pfrl.utils.recurrent import pack_and_forward
+from pfrl.utils.recurrent import (
+    concatenate_recurrent_states,
+    flatten_sequences_time_first,
+    get_recurrent_state_at,
+    mask_recurrent_state_at,
+    one_step_forward,
+    pack_and_forward,
+)
 
 
 def _mean_or_nan(xs):

--- a/pfrl/agents/reinforce.py
+++ b/pfrl/agents/reinforce.py
@@ -1,14 +1,14 @@
-from logging import getLogger
 import warnings
+from logging import getLogger
 
 import numpy as np
 import torch
 
 import pfrl
 from pfrl import agent
+from pfrl.utils import clip_l2_grad_norm_
 from pfrl.utils.mode_of_distribution import mode_of_distribution
 from pfrl.utils.recurrent import one_step_forward
-from pfrl.utils import clip_l2_grad_norm_
 
 
 class REINFORCE(agent.AttributeSavingMixin, agent.Agent):

--- a/pfrl/agents/soft_actor_critic.py
+++ b/pfrl/agents/soft_actor_critic.py
@@ -8,14 +8,12 @@ from torch import nn
 from torch.nn import functional as F
 
 import pfrl
-from pfrl.agent import AttributeSavingMixin
-from pfrl.agent import BatchAgent
+from pfrl.agent import AttributeSavingMixin, BatchAgent
+from pfrl.replay_buffer import ReplayUpdater, batch_experiences
+from pfrl.utils import clip_l2_grad_norm_
 from pfrl.utils.batch_states import batch_states
 from pfrl.utils.copy_param import synchronize_parameters
 from pfrl.utils.mode_of_distribution import mode_of_distribution
-from pfrl.replay_buffer import batch_experiences
-from pfrl.replay_buffer import ReplayUpdater
-from pfrl.utils import clip_l2_grad_norm_
 
 
 def _mean_or_nan(xs):

--- a/pfrl/agents/state_q_function_actor.py
+++ b/pfrl/agents/state_q_function_actor.py
@@ -3,11 +3,13 @@ from logging import getLogger
 import torch
 
 from pfrl import agent
-from pfrl.utils.batch_states import batch_states
 from pfrl.utils import evaluating
-from pfrl.utils.recurrent import one_step_forward
-from pfrl.utils.recurrent import get_recurrent_state_at
-from pfrl.utils.recurrent import recurrent_state_as_numpy
+from pfrl.utils.batch_states import batch_states
+from pfrl.utils.recurrent import (
+    get_recurrent_state_at,
+    one_step_forward,
+    recurrent_state_as_numpy,
+)
 
 
 class StateQFunctionActor(agent.AsyncAgent):

--- a/pfrl/agents/td3.py
+++ b/pfrl/agents/td3.py
@@ -7,13 +7,11 @@ import torch
 from torch.nn import functional as F
 
 import pfrl
-from pfrl.agent import AttributeSavingMixin
-from pfrl.agent import BatchAgent
+from pfrl.agent import AttributeSavingMixin, BatchAgent
+from pfrl.replay_buffer import ReplayUpdater, batch_experiences
+from pfrl.utils import clip_l2_grad_norm_
 from pfrl.utils.batch_states import batch_states
 from pfrl.utils.copy_param import synchronize_parameters
-from pfrl.replay_buffer import batch_experiences
-from pfrl.replay_buffer import ReplayUpdater
-from pfrl.utils import clip_l2_grad_norm_
 
 
 def _mean_or_nan(xs):

--- a/pfrl/agents/trpo.py
+++ b/pfrl/agents/trpo.py
@@ -1,6 +1,6 @@
 import collections
-from logging import getLogger
 import random
+from logging import getLogger
 
 import numpy as np
 import torch
@@ -9,22 +9,24 @@ from torch import nn
 
 import pfrl
 from pfrl import agent
-from pfrl.agents.ppo import _compute_explained_variance
-from pfrl.agents.ppo import _make_dataset
-from pfrl.agents.ppo import _make_dataset_recurrent
-from pfrl.agents.ppo import _yield_minibatches
-from pfrl.agents.ppo import (
+from pfrl.agents.ppo import (  # NOQA
+    _compute_explained_variance,
+    _make_dataset,
+    _make_dataset_recurrent,
+    _yield_minibatches,
     _yield_subset_of_sequences_with_fixed_number_of_items,
-)  # NOQA
-from pfrl.utils.mode_of_distribution import mode_of_distribution
-from pfrl.utils.batch_states import batch_states
-from pfrl.utils.recurrent import flatten_sequences_time_first
-from pfrl.utils.recurrent import one_step_forward
-from pfrl.utils.recurrent import pack_and_forward
-from pfrl.utils.recurrent import get_recurrent_state_at
-from pfrl.utils.recurrent import mask_recurrent_state_at
-from pfrl.utils.recurrent import concatenate_recurrent_states
+)
 from pfrl.utils import clip_l2_grad_norm_
+from pfrl.utils.batch_states import batch_states
+from pfrl.utils.mode_of_distribution import mode_of_distribution
+from pfrl.utils.recurrent import (
+    concatenate_recurrent_states,
+    flatten_sequences_time_first,
+    get_recurrent_state_at,
+    mask_recurrent_state_at,
+    one_step_forward,
+    pack_and_forward,
+)
 
 
 def _flatten_and_concat_variables(vs):

--- a/pfrl/collections/persistent_collections.py
+++ b/pfrl/collections/persistent_collections.py
@@ -1,12 +1,11 @@
 import binascii
 import collections
-from datetime import datetime
-from struct import pack, unpack, calcsize
 import os
 import pickle
+from datetime import datetime
+from struct import calcsize, pack, unpack
 
 from pfrl.collections.random_access_queue import RandomAccessQueue
-
 
 # code for future extension. `_VanillaFS` is a dummy of chainerio's
 # FIleSystem class.

--- a/pfrl/distributions/delta.py
+++ b/pfrl/distributions/delta.py
@@ -1,7 +1,7 @@
 from numbers import Number
 
 import torch
-from torch.distributions import constraints, Distribution
+from torch.distributions import Distribution, constraints
 
 
 class Delta(Distribution):

--- a/pfrl/env.py
+++ b/pfrl/env.py
@@ -1,5 +1,4 @@
-from abc import ABCMeta
-from abc import abstractmethod
+from abc import ABCMeta, abstractmethod
 
 
 class Env(object, metaclass=ABCMeta):

--- a/pfrl/envs/abc.py
+++ b/pfrl/envs/abc.py
@@ -1,5 +1,5 @@
-from gym import spaces
 import numpy as np
+from gym import spaces
 
 from pfrl import env
 

--- a/pfrl/envs/multiprocess_vector_env.py
+++ b/pfrl/envs/multiprocess_vector_env.py
@@ -1,7 +1,6 @@
-from multiprocessing import Pipe
-from multiprocessing import Process
 import signal
 import warnings
+from multiprocessing import Pipe, Process
 
 import numpy as np
 from torch.distributions.utils import lazy_property

--- a/pfrl/experiments/__init__.py
+++ b/pfrl/experiments/__init__.py
@@ -1,12 +1,9 @@
 from pfrl.experiments.evaluator import eval_performance  # NOQA
-
 from pfrl.experiments.hooks import LinearInterpolationHook  # NOQA
 from pfrl.experiments.hooks import StepHook  # NOQA
-
-from pfrl.experiments.prepare_output_dir import is_under_git_control  # NOQA
 from pfrl.experiments.prepare_output_dir import generate_exp_id  # NOQA
+from pfrl.experiments.prepare_output_dir import is_under_git_control  # NOQA
 from pfrl.experiments.prepare_output_dir import prepare_output_dir  # NOQA
-
 from pfrl.experiments.train_agent import train_agent  # NOQA
 from pfrl.experiments.train_agent import train_agent_with_evaluation  # NOQA
 from pfrl.experiments.train_agent_async import train_agent_async  # NOQA

--- a/pfrl/experiments/hooks.py
+++ b/pfrl/experiments/hooks.py
@@ -1,5 +1,4 @@
-from abc import ABCMeta
-from abc import abstractmethod
+from abc import ABCMeta, abstractmethod
 
 import numpy as np
 

--- a/pfrl/experiments/prepare_output_dir.py
+++ b/pfrl/experiments/prepare_output_dir.py
@@ -1,5 +1,4 @@
 import argparse
-from binascii import crc32
 import datetime
 import json
 import os
@@ -7,6 +6,7 @@ import pickle
 import shutil
 import subprocess
 import sys
+from binascii import crc32
 
 import pfrl
 

--- a/pfrl/experiments/train_agent.py
+++ b/pfrl/experiments/train_agent.py
@@ -1,8 +1,7 @@
 import logging
 import os
 
-from pfrl.experiments.evaluator import Evaluator
-from pfrl.experiments.evaluator import save_agent
+from pfrl.experiments.evaluator import Evaluator, save_agent
 from pfrl.utils.ask_yes_no import ask_yes_no
 
 

--- a/pfrl/experiments/train_agent_async.py
+++ b/pfrl/experiments/train_agent_async.py
@@ -1,17 +1,16 @@
 import logging
-import torch.multiprocessing as mp
 import os
-import torch
-from torch import nn
-
-import numpy as np
-
-from pfrl.experiments.evaluator import AsyncEvaluator
-from pfrl.utils import async_
-from pfrl.utils import random_seed
 import signal
 import subprocess
 import sys
+
+import numpy as np
+import torch
+import torch.multiprocessing as mp
+from torch import nn
+
+from pfrl.experiments.evaluator import AsyncEvaluator
+from pfrl.utils import async_, random_seed
 
 
 def kill_all():

--- a/pfrl/experiments/train_agent_batch.py
+++ b/pfrl/experiments/train_agent_batch.py
@@ -1,12 +1,10 @@
-from collections import deque
 import logging
 import os
+from collections import deque
 
 import numpy as np
 
-
-from pfrl.experiments.evaluator import Evaluator
-from pfrl.experiments.evaluator import save_agent
+from pfrl.experiments.evaluator import Evaluator, save_agent
 
 
 def train_agent_batch(

--- a/pfrl/explorer.py
+++ b/pfrl/explorer.py
@@ -1,5 +1,4 @@
-from abc import ABCMeta
-from abc import abstractmethod
+from abc import ABCMeta, abstractmethod
 
 
 class Explorer(object, metaclass=ABCMeta):

--- a/pfrl/explorers/__init__.py
+++ b/pfrl/explorers/__init__.py
@@ -2,6 +2,6 @@ from pfrl.explorers.additive_gaussian import AdditiveGaussian  # NOQA
 from pfrl.explorers.additive_ou import AdditiveOU  # NOQA
 from pfrl.explorers.boltzmann import Boltzmann  # NOQA
 from pfrl.explorers.epsilon_greedy import ConstantEpsilonGreedy  # NOQA
-from pfrl.explorers.epsilon_greedy import LinearDecayEpsilonGreedy  # NOQA
 from pfrl.explorers.epsilon_greedy import ExponentialDecayEpsilonGreedy  # NOQA
+from pfrl.explorers.epsilon_greedy import LinearDecayEpsilonGreedy  # NOQA
 from pfrl.explorers.greedy import Greedy  # NOQA

--- a/pfrl/explorers/boltzmann.py
+++ b/pfrl/explorers/boltzmann.py
@@ -1,6 +1,6 @@
+import numpy as np
 import torch
 import torch.nn.functional as F
-import numpy as np
 
 import pfrl
 

--- a/pfrl/functions/lower_triangular_matrix.py
+++ b/pfrl/functions/lower_triangular_matrix.py
@@ -1,5 +1,5 @@
-import torch
 import numpy as np
+import torch
 
 
 def set_batch_non_diagonal(array, non_diag_val):

--- a/pfrl/initializers/__init__.py
+++ b/pfrl/initializers/__init__.py
@@ -1,4 +1,3 @@
 # Add lecun_normal weight initialization for networks in pytorch
-from pfrl.initializers.lecun_normal import init_lecun_normal  # NOQA
-
 from pfrl.initializers.chainer_default import init_chainer_default  # NOQA
+from pfrl.initializers.lecun_normal import init_lecun_normal  # NOQA

--- a/pfrl/initializers/chainer_default.py
+++ b/pfrl/initializers/chainer_default.py
@@ -2,6 +2,7 @@
 """
 import torch
 import torch.nn as nn
+
 from pfrl.initializers import init_lecun_normal
 
 

--- a/pfrl/initializers/chainer_default.py
+++ b/pfrl/initializers/chainer_default.py
@@ -3,7 +3,7 @@
 import torch
 import torch.nn as nn
 
-from pfrl.initializers import init_lecun_normal
+from pfrl.initializers.lecun_normal import init_lecun_normal
 
 
 @torch.no_grad()

--- a/pfrl/nn/__init__.py
+++ b/pfrl/nn/__init__.py
@@ -1,7 +1,10 @@
-from pfrl.nn.branched import Branched  # NOQA
 from pfrl.nn.atari_cnn import LargeAtariCNN  # NOQA
 from pfrl.nn.atari_cnn import SmallAtariCNN  # NOQA
+from pfrl.nn.bound_by_tanh import BoundByTanh  # NOQA
+from pfrl.nn.branched import Branched  # NOQA
+from pfrl.nn.concat_obs_and_action import ConcatObsAndAction  # NOQA
 from pfrl.nn.empirical_normalization import EmpiricalNormalization  # NOQA
+from pfrl.nn.lmbda import Lambda  # NOQA
 from pfrl.nn.mlp import MLP  # NOQA
 from pfrl.nn.mlp_bn import MLPBN  # NOQA
 from pfrl.nn.noisy_chain import to_factorized_noisy  # NOQA
@@ -9,6 +12,3 @@ from pfrl.nn.noisy_linear import FactorizedNoisyLinear  # NOQA
 from pfrl.nn.recurrent import Recurrent  # NOQA
 from pfrl.nn.recurrent_branched import RecurrentBranched  # NOQA
 from pfrl.nn.recurrent_sequential import RecurrentSequential  # NOQA
-from pfrl.nn.lmbda import Lambda  # NOQA
-from pfrl.nn.concat_obs_and_action import ConcatObsAndAction  # NOQA
-from pfrl.nn.bound_by_tanh import BoundByTanh  # NOQA

--- a/pfrl/nn/atari_cnn.py
+++ b/pfrl/nn/atari_cnn.py
@@ -1,6 +1,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
 from pfrl.initializers import init_chainer_default
 
 

--- a/pfrl/nn/concat_obs_and_action.py
+++ b/pfrl/nn/concat_obs_and_action.py
@@ -1,6 +1,6 @@
 import torch
 
-from pfrl.nn import Lambda
+from pfrl.nn.lmbda import Lambda
 
 
 def concat_obs_and_action(obs_and_action):

--- a/pfrl/nn/empirical_normalization.py
+++ b/pfrl/nn/empirical_normalization.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 import torch
 from torch import nn
 

--- a/pfrl/nn/mlp.py
+++ b/pfrl/nn/mlp.py
@@ -1,7 +1,7 @@
 import torch.nn as nn
 import torch.nn.functional as F
-from pfrl.initializers import init_chainer_default
-from pfrl.initializers import init_lecun_normal
+
+from pfrl.initializers import init_chainer_default, init_lecun_normal
 
 
 class MLP(nn.Module):

--- a/pfrl/nn/mlp_bn.py
+++ b/pfrl/nn/mlp_bn.py
@@ -1,5 +1,6 @@
 import torch.nn as nn
 import torch.nn.functional as F
+
 from pfrl.initializers import init_lecun_normal
 
 

--- a/pfrl/nn/noisy_linear.py
+++ b/pfrl/nn/noisy_linear.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/pfrl/nn/recurrent_sequential.py
+++ b/pfrl/nn/recurrent_sequential.py
@@ -1,10 +1,12 @@
 from torch import nn
 
 from pfrl.nn.recurrent import Recurrent
-from pfrl.utils.recurrent import is_recurrent
-from pfrl.utils.recurrent import get_packed_sequence_info
-from pfrl.utils.recurrent import wrap_packed_sequences_recursive
-from pfrl.utils.recurrent import unwrap_packed_sequences_recursive
+from pfrl.utils.recurrent import (
+    get_packed_sequence_info,
+    is_recurrent,
+    unwrap_packed_sequences_recursive,
+    wrap_packed_sequences_recursive,
+)
 
 
 class RecurrentSequential(Recurrent, nn.Sequential):

--- a/pfrl/policy.py
+++ b/pfrl/policy.py
@@ -1,7 +1,4 @@
-from abc import ABCMeta
-from abc import abstractmethod
-
-
+from abc import ABCMeta, abstractmethod
 from logging import getLogger
 
 logger = getLogger(__name__)

--- a/pfrl/q_function.py
+++ b/pfrl/q_function.py
@@ -1,5 +1,4 @@
-from abc import ABCMeta
-from abc import abstractmethod
+from abc import ABCMeta, abstractmethod
 
 
 class StateQFunction(object, metaclass=ABCMeta):

--- a/pfrl/q_functions/dueling_dqn.py
+++ b/pfrl/q_functions/dueling_dqn.py
@@ -3,9 +3,9 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from pfrl import action_value
+from pfrl.initializers import init_chainer_default
 from pfrl.nn.mlp import MLP
 from pfrl.q_function import StateQFunction
-from pfrl.initializers import init_chainer_default
 
 
 def constant_bias_initializer(bias=0.0):

--- a/pfrl/q_functions/state_action_q_functions.py
+++ b/pfrl/q_functions/state_action_q_functions.py
@@ -1,11 +1,11 @@
-from pfrl.nn.mlp import MLP
-from pfrl.nn.mlp_bn import MLPBN
-from pfrl.q_function import StateActionQFunction
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
 from pfrl.initializers import init_lecun_normal
+from pfrl.nn.mlp import MLP
+from pfrl.nn.mlp_bn import MLPBN
+from pfrl.q_function import StateActionQFunction
 
 
 class SingleModelStateActionQFunction(nn.Module, StateActionQFunction):

--- a/pfrl/q_functions/state_q_functions.py
+++ b/pfrl/q_functions/state_q_functions.py
@@ -1,17 +1,18 @@
 import numpy as np
-
-from pfrl.action_value import DiscreteActionValue
-from pfrl.action_value import DistributionalDiscreteActionValue
-from pfrl.action_value import QuadraticActionValue
-from pfrl.functions.lower_triangular_matrix import lower_triangular_matrix
-from pfrl.nn import Lambda
-from pfrl.nn.mlp import MLP
-from pfrl.q_function import StateQFunction
-
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+from pfrl.action_value import (
+    DiscreteActionValue,
+    DistributionalDiscreteActionValue,
+    QuadraticActionValue,
+)
+from pfrl.functions.lower_triangular_matrix import lower_triangular_matrix
 from pfrl.initializers import init_chainer_default
+from pfrl.nn import Lambda
+from pfrl.nn.mlp import MLP
+from pfrl.q_function import StateQFunction
 
 
 def scale_by_tanh(x, low, high):

--- a/pfrl/replay_buffer.py
+++ b/pfrl/replay_buffer.py
@@ -1,15 +1,15 @@
-from abc import ABCMeta
-from abc import abstractmethod
-from abc import abstractproperty
+from abc import ABCMeta, abstractmethod, abstractproperty
 from typing import Optional
 
 import numpy as np
 import torch
 
 from pfrl.utils.batch_states import batch_states
-from pfrl.utils.recurrent import concatenate_recurrent_states
-from pfrl.utils.recurrent import flatten_sequences_time_first
-from pfrl.utils.recurrent import recurrent_state_from_numpy
+from pfrl.utils.recurrent import (
+    concatenate_recurrent_states,
+    flatten_sequences_time_first,
+    recurrent_state_from_numpy,
+)
 
 
 class AbstractReplayBuffer(object, metaclass=ABCMeta):

--- a/pfrl/replay_buffers/episodic.py
+++ b/pfrl/replay_buffers/episodic.py
@@ -3,8 +3,7 @@ import pickle
 from typing import Optional
 
 from pfrl.collections.random_access_queue import RandomAccessQueue
-from pfrl.replay_buffer import AbstractEpisodicReplayBuffer
-from pfrl.replay_buffer import random_subseq
+from pfrl.replay_buffer import AbstractEpisodicReplayBuffer, random_subseq
 
 
 class EpisodicReplayBuffer(AbstractEpisodicReplayBuffer):

--- a/pfrl/replay_buffers/persistent.py
+++ b/pfrl/replay_buffers/persistent.py
@@ -1,10 +1,10 @@
 import os
 import warnings
 
-from .replay_buffer import ReplayBuffer
-from .episodic import EpisodicReplayBuffer
-
 from pfrl.collections.persistent_collections import PersistentRandomAccessQueue
+
+from .episodic import EpisodicReplayBuffer
+from .replay_buffer import ReplayBuffer
 
 
 class PersistentReplayBuffer(ReplayBuffer):

--- a/pfrl/replay_buffers/prioritized_episodic.py
+++ b/pfrl/replay_buffers/prioritized_episodic.py
@@ -1,10 +1,9 @@
 import collections
 
-from pfrl.collections.random_access_queue import RandomAccessQueue
 from pfrl.collections.prioritized import PrioritizedBuffer
+from pfrl.collections.random_access_queue import RandomAccessQueue
 from pfrl.replay_buffer import random_subseq
-from pfrl.replay_buffers import EpisodicReplayBuffer
-from pfrl.replay_buffers import PriorityWeightError
+from pfrl.replay_buffers import EpisodicReplayBuffer, PriorityWeightError
 
 
 class PrioritizedEpisodicReplayBuffer(EpisodicReplayBuffer, PriorityWeightError):

--- a/pfrl/replay_buffers/replay_buffer.py
+++ b/pfrl/replay_buffers/replay_buffer.py
@@ -2,8 +2,8 @@ import collections
 import pickle
 from typing import Optional
 
-from pfrl.collections.random_access_queue import RandomAccessQueue
 from pfrl import replay_buffer
+from pfrl.collections.random_access_queue import RandomAccessQueue
 
 
 class ReplayBuffer(replay_buffer.AbstractReplayBuffer):

--- a/pfrl/utils/__init__.py
+++ b/pfrl/utils/__init__.py
@@ -1,9 +1,9 @@
-from pfrl.utils.batch_states import batch_states  # NOQA
-from pfrl.utils.conjugate_gradient import conjugate_gradient  # NOQA
 from pfrl.utils import env_modifiers  # NOQA
-from pfrl.utils.is_return_code_zero import is_return_code_zero  # NOQA
-from pfrl.utils.random_seed import set_random_seed  # NOQA
-from pfrl.utils.pretrained_models import download_model  # NOQA
-from pfrl.utils.contexts import evaluating  # NOQA
-from pfrl.utils.stoppable_thread import StoppableThread  # NOQA
+from pfrl.utils.batch_states import batch_states  # NOQA
 from pfrl.utils.clip_l2_grad_norm import clip_l2_grad_norm_  # NOQA
+from pfrl.utils.conjugate_gradient import conjugate_gradient  # NOQA
+from pfrl.utils.contexts import evaluating  # NOQA
+from pfrl.utils.is_return_code_zero import is_return_code_zero  # NOQA
+from pfrl.utils.pretrained_models import download_model  # NOQA
+from pfrl.utils.random_seed import set_random_seed  # NOQA
+from pfrl.utils.stoppable_thread import StoppableThread  # NOQA

--- a/pfrl/utils/async_.py
+++ b/pfrl/utils/async_.py
@@ -1,5 +1,6 @@
-import torch.multiprocessing as mp
 import warnings
+
+import torch.multiprocessing as mp
 
 
 class AbnormalExitWarning(Warning):

--- a/pfrl/utils/batch_states.py
+++ b/pfrl/utils/batch_states.py
@@ -1,6 +1,4 @@
-from typing import Any
-from typing import Callable
-from typing import Sequence
+from typing import Any, Callable, Sequence
 
 import torch
 from torch.utils.data._utils.collate import default_collate

--- a/pfrl/utils/random_seed.py
+++ b/pfrl/utils/random_seed.py
@@ -1,6 +1,7 @@
 import random
-import torch
+
 import numpy as np
+import torch
 
 
 def set_random_seed(seed):

--- a/pfrl/wrappers/__init__.py
+++ b/pfrl/wrappers/__init__.py
@@ -1,16 +1,9 @@
 from pfrl.wrappers.cast_observation import CastObservation  # NOQA
 from pfrl.wrappers.cast_observation import CastObservationToFloat32  # NOQA
-
 from pfrl.wrappers.continuing_time_limit import ContinuingTimeLimit  # NOQA
-
 from pfrl.wrappers.monitor import Monitor  # NOQA
-
 from pfrl.wrappers.normalize_action_space import NormalizeActionSpace  # NOQA
-
 from pfrl.wrappers.randomize_action import RandomizeAction  # NOQA
-
 from pfrl.wrappers.render import Render  # NOQA
-
 from pfrl.wrappers.scale_reward import ScaleReward  # NOQA
-
 from pfrl.wrappers.vector_frame_stack import VectorFrameStack  # NOQA

--- a/pfrl/wrappers/atari_wrappers.py
+++ b/pfrl/wrappers/atari_wrappers.py
@@ -6,11 +6,9 @@ from collections import deque
 
 import gym
 import numpy as np
-
 from gym import spaces
 
 import pfrl
-
 
 try:
     import cv2

--- a/pfrl/wrappers/monitor.py
+++ b/pfrl/wrappers/monitor.py
@@ -1,5 +1,5 @@
-from logging import getLogger
 import time
+from logging import getLogger
 
 from gym.wrappers import Monitor as _GymMonitor
 from gym.wrappers.monitoring.stats_recorder import StatsRecorder as _GymStatsRecorder

--- a/pfrl/wrappers/vector_frame_stack.py
+++ b/pfrl/wrappers/vector_frame_stack.py
@@ -1,7 +1,7 @@
 from collections import deque
 
-from gym import spaces
 import numpy as np
+from gym import spaces
 
 from pfrl.env import VectorEnv
 from pfrl.wrappers.atari_wrappers import LazyFrames

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,3 +35,11 @@ ignore_missing_imports = True
 
 [mypy-slimevolleygym.*]
 ignore_missing_imports = True
+
+[isort]
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+ensure_newline_before_comments = True
+line_length = 88

--- a/tests/agents_tests/basetest_ddpg.py
+++ b/tests/agents_tests/basetest_ddpg.py
@@ -1,16 +1,13 @@
 import numpy as np
 import torch
+from basetest_training import _TestTraining
 from torch import nn
 
+from pfrl import replay_buffers
 from pfrl.envs.abc import ABC
 from pfrl.explorers.epsilon_greedy import LinearDecayEpsilonGreedy
-from pfrl import replay_buffers
-from pfrl.nn import RecurrentSequential
-from pfrl.nn import ConcatObsAndAction
-from pfrl.nn import BoundByTanh
+from pfrl.nn import BoundByTanh, ConcatObsAndAction, RecurrentSequential
 from pfrl.policies import DeterministicHead
-
-from basetest_training import _TestTraining
 
 
 class _TestDDPGOnABC(_TestTraining):

--- a/tests/agents_tests/basetest_dqn_like.py
+++ b/tests/agents_tests/basetest_dqn_like.py
@@ -1,14 +1,12 @@
 import numpy as np
 import torch.nn as nn
 import torch.optim as optim
+from basetest_training import _TestTraining
 
+from pfrl import q_functions, replay_buffers
 from pfrl.envs.abc import ABC
 from pfrl.explorers.epsilon_greedy import LinearDecayEpsilonGreedy
 from pfrl.nn import RecurrentSequential
-from pfrl import q_functions
-from pfrl import replay_buffers
-
-from basetest_training import _TestTraining
 
 
 class _TestDQNLike(_TestTraining):

--- a/tests/agents_tests/basetest_training.py
+++ b/tests/agents_tests/basetest_training.py
@@ -1,16 +1,20 @@
 import logging
 import os
 import tempfile
-import pytest
 
 import numpy as np
+import pytest
 
 import pfrl
-from pfrl.experiments.evaluator import batch_run_evaluation_episodes
-from pfrl.experiments.evaluator import run_evaluation_episodes
-from pfrl.experiments import train_agent_async
-from pfrl.experiments import train_agent_batch_with_evaluation
-from pfrl.experiments import train_agent_with_evaluation
+from pfrl.experiments import (
+    train_agent_async,
+    train_agent_batch_with_evaluation,
+    train_agent_with_evaluation,
+)
+from pfrl.experiments.evaluator import (
+    batch_run_evaluation_episodes,
+    run_evaluation_episodes,
+)
 from pfrl.utils import random_seed
 
 

--- a/tests/agents_tests/test_a2c.py
+++ b/tests/agents_tests/test_a2c.py
@@ -11,8 +11,10 @@ from pfrl.agents.a2c import A2C
 from pfrl.envs.abc import ABC
 from pfrl.experiments.evaluator import batch_run_evaluation_episodes
 from pfrl.nn import Branched
-from pfrl.policies import SoftmaxCategoricalHead
-from pfrl.policies import GaussianHeadWithStateIndependentCovariance
+from pfrl.policies import (
+    GaussianHeadWithStateIndependentCovariance,
+    SoftmaxCategoricalHead,
+)
 
 
 @pytest.mark.parametrize("num_processes", [1, 3])

--- a/tests/agents_tests/test_a3c.py
+++ b/tests/agents_tests/test_a3c.py
@@ -11,12 +11,13 @@ from torch import nn
 import pfrl
 from pfrl.agents import a3c
 from pfrl.envs.abc import ABC
-from pfrl.experiments.train_agent_async import train_agent_async
 from pfrl.experiments.evaluator import run_evaluation_episodes
-from pfrl.nn import RecurrentBranched
-from pfrl.nn import RecurrentSequential
-from pfrl.policies import SoftmaxCategoricalHead
-from pfrl.policies import GaussianHeadWithStateIndependentCovariance
+from pfrl.experiments.train_agent_async import train_agent_async
+from pfrl.nn import RecurrentBranched, RecurrentSequential
+from pfrl.policies import (
+    GaussianHeadWithStateIndependentCovariance,
+    SoftmaxCategoricalHead,
+)
 
 
 class _TestA3C:

--- a/tests/agents_tests/test_acer.py
+++ b/tests/agents_tests/test_acer.py
@@ -12,13 +12,12 @@ from torch import nn
 import pfrl
 from pfrl.agents import acer
 from pfrl.envs.abc import ABC
-from pfrl.experiments.train_agent_async import train_agent_async
 from pfrl.experiments.evaluator import run_evaluation_episodes
-from pfrl.replay_buffers import EpisodicReplayBuffer
-from pfrl.policies import GaussianHeadWithDiagonalCovariance
-from pfrl.policies import SoftmaxCategoricalHead
-from pfrl.q_functions import DiscreteActionValueHead
+from pfrl.experiments.train_agent_async import train_agent_async
 from pfrl.nn import ConcatObsAndAction
+from pfrl.policies import GaussianHeadWithDiagonalCovariance, SoftmaxCategoricalHead
+from pfrl.q_functions import DiscreteActionValueHead
+from pfrl.replay_buffers import EpisodicReplayBuffer
 
 
 def extract_gradients_as_single_vector(mod):

--- a/tests/agents_tests/test_al.py
+++ b/tests/agents_tests/test_al.py
@@ -1,5 +1,6 @@
 import basetest_dqn_like as base
 from basetest_training import _TestBatchTrainingMixin
+
 from pfrl.agents.al import AL
 
 

--- a/tests/agents_tests/test_categorical_dqn.py
+++ b/tests/agents_tests/test_categorical_dqn.py
@@ -1,19 +1,14 @@
 import unittest
 
-
-import numpy as np
-
 import basetest_dqn_like as base
-from basetest_training import _TestBatchTrainingMixin
-import pfrl
-from pfrl.agents import categorical_dqn
-from pfrl.agents.categorical_dqn import compute_value_loss
-from pfrl.agents.categorical_dqn import compute_weighted_value_loss
-from pfrl.agents import CategoricalDQN
-
-
-import torch
+import numpy as np
 import pytest
+import torch
+from basetest_training import _TestBatchTrainingMixin
+
+import pfrl
+from pfrl.agents import CategoricalDQN, categorical_dqn
+from pfrl.agents.categorical_dqn import compute_value_loss, compute_weighted_value_loss
 
 assertions = unittest.TestCase("__init__")
 

--- a/tests/agents_tests/test_ddpg.py
+++ b/tests/agents_tests/test_ddpg.py
@@ -1,8 +1,8 @@
+import basetest_ddpg as base
 import pytest
+from basetest_training import _TestBatchTrainingMixin
 
 from pfrl.agents.ddpg import DDPG
-import basetest_ddpg as base
-from basetest_training import _TestBatchTrainingMixin
 
 
 @pytest.mark.skip  # recurrent=True is not supported yet

--- a/tests/agents_tests/test_double_categorical_dqn.py
+++ b/tests/agents_tests/test_double_categorical_dqn.py
@@ -1,6 +1,5 @@
-import torch.nn as nn
-
 import basetest_dqn_like as base
+import torch.nn as nn
 from basetest_training import _TestBatchTrainingMixin
 
 import pfrl

--- a/tests/agents_tests/test_double_dqn.py
+++ b/tests/agents_tests/test_double_dqn.py
@@ -1,5 +1,6 @@
 import basetest_dqn_like
 from basetest_training import _TestBatchTrainingMixin
+
 from pfrl.agents.double_dqn import DoubleDQN
 
 

--- a/tests/agents_tests/test_double_pal.py
+++ b/tests/agents_tests/test_double_pal.py
@@ -1,7 +1,7 @@
-from pfrl.agents.double_pal import DoublePAL
-
 import basetest_dqn_like
 from basetest_training import _TestBatchTrainingMixin
+
+from pfrl.agents.double_pal import DoublePAL
 
 
 class TestDoublePALOnDiscreteABC(

--- a/tests/agents_tests/test_dpp.py
+++ b/tests/agents_tests/test_dpp.py
@@ -1,9 +1,8 @@
-import pytest
 import basetest_dqn_like as base
+import pytest
 from basetest_training import _TestBatchTrainingMixin
-from pfrl.agents.dpp import DPP
-from pfrl.agents.dpp import DPPGreedy
-from pfrl.agents.dpp import DPPL
+
+from pfrl.agents.dpp import DPP, DPPL, DPPGreedy
 
 
 def parse_dpp_agent(dpp_type):

--- a/tests/agents_tests/test_dqn.py
+++ b/tests/agents_tests/test_dqn.py
@@ -1,14 +1,12 @@
 import unittest
 
+import basetest_dqn_like as base
 import pytest
 import torch
-import basetest_dqn_like as base
+from basetest_training import _TestActorLearnerTrainingMixin, _TestBatchTrainingMixin
+
 import pfrl
-from pfrl.agents.dqn import compute_value_loss
-from pfrl.agents.dqn import compute_weighted_value_loss
-from pfrl.agents.dqn import DQN
-from basetest_training import _TestActorLearnerTrainingMixin
-from basetest_training import _TestBatchTrainingMixin
+from pfrl.agents.dqn import DQN, compute_value_loss, compute_weighted_value_loss
 
 assertions = unittest.TestCase("__init__")
 

--- a/tests/agents_tests/test_iqn.py
+++ b/tests/agents_tests/test_iqn.py
@@ -1,13 +1,13 @@
-import numpy as np
-import torch
-from torch import nn
-import pytest
-
 import basetest_dqn_like as base
+import numpy as np
+import pytest
+import torch
 
 # IQN does not support the actor-learner interface for now
 # from basetest_training import _TestActorLearnerTrainingMixin
 from basetest_training import _TestBatchTrainingMixin
+from torch import nn
+
 import pfrl
 from pfrl.agents import iqn
 from pfrl.testing import torch_assert_allclose

--- a/tests/agents_tests/test_pal.py
+++ b/tests/agents_tests/test_pal.py
@@ -1,5 +1,6 @@
 import basetest_dqn_like as base
 from basetest_training import _TestBatchTrainingMixin
+
 from pfrl.agents.pal import PAL
 
 

--- a/tests/agents_tests/test_ppo.py
+++ b/tests/agents_tests/test_ppo.py
@@ -13,17 +13,21 @@ import pfrl
 from pfrl.agents import ppo
 from pfrl.agents.ppo import PPO
 from pfrl.envs.abc import ABC
-from pfrl.experiments.evaluator import batch_run_evaluation_episodes
-from pfrl.experiments.evaluator import run_evaluation_episodes
-from pfrl.experiments import train_agent_batch_with_evaluation
-from pfrl.experiments import train_agent_with_evaluation
-from pfrl.utils.batch_states import batch_states
-
-from pfrl.nn import RecurrentBranched
-from pfrl.nn import RecurrentSequential
-from pfrl.policies import SoftmaxCategoricalHead
-from pfrl.policies import GaussianHeadWithStateIndependentCovariance
+from pfrl.experiments import (
+    train_agent_batch_with_evaluation,
+    train_agent_with_evaluation,
+)
+from pfrl.experiments.evaluator import (
+    batch_run_evaluation_episodes,
+    run_evaluation_episodes,
+)
+from pfrl.nn import RecurrentBranched, RecurrentSequential
+from pfrl.policies import (
+    GaussianHeadWithStateIndependentCovariance,
+    SoftmaxCategoricalHead,
+)
 from pfrl.testing import torch_assert_allclose
+from pfrl.utils.batch_states import batch_states
 
 
 def make_random_episodes(n_episodes=10, obs_size=2, n_actions=3):

--- a/tests/agents_tests/test_reinforce.py
+++ b/tests/agents_tests/test_reinforce.py
@@ -2,15 +2,17 @@ import logging
 import tempfile
 
 import numpy as np
+import pytest
 import torch
 from torch import nn
-import pytest
 
 import pfrl
-from pfrl.experiments.evaluator import run_evaluation_episodes
 from pfrl.envs.abc import ABC
-from pfrl.policies import SoftmaxCategoricalHead
-from pfrl.policies import GaussianHeadWithStateIndependentCovariance
+from pfrl.experiments.evaluator import run_evaluation_episodes
+from pfrl.policies import (
+    GaussianHeadWithStateIndependentCovariance,
+    SoftmaxCategoricalHead,
+)
 
 
 @pytest.mark.parametrize("discrete", [True, False])

--- a/tests/agents_tests/test_soft_actor_critic.py
+++ b/tests/agents_tests/test_soft_actor_critic.py
@@ -4,16 +4,18 @@ import tempfile
 import numpy as np
 import pytest
 import torch
-from torch import distributions
-from torch import nn
-
+from torch import distributions, nn
 
 import pfrl
 from pfrl.envs.abc import ABC
-from pfrl.experiments.evaluator import batch_run_evaluation_episodes
-from pfrl.experiments.evaluator import run_evaluation_episodes
-from pfrl.experiments import train_agent_batch_with_evaluation
-from pfrl.experiments import train_agent_with_evaluation
+from pfrl.experiments import (
+    train_agent_batch_with_evaluation,
+    train_agent_with_evaluation,
+)
+from pfrl.experiments.evaluator import (
+    batch_run_evaluation_episodes,
+    run_evaluation_episodes,
+)
 from pfrl.nn.lmbda import Lambda
 
 

--- a/tests/agents_tests/test_td3.py
+++ b/tests/agents_tests/test_td3.py
@@ -8,10 +8,14 @@ from torch import nn
 
 import pfrl
 from pfrl.envs.abc import ABC
-from pfrl.experiments.evaluator import batch_run_evaluation_episodes
-from pfrl.experiments.evaluator import run_evaluation_episodes
-from pfrl.experiments import train_agent_batch_with_evaluation
-from pfrl.experiments import train_agent_with_evaluation
+from pfrl.experiments import (
+    train_agent_batch_with_evaluation,
+    train_agent_with_evaluation,
+)
+from pfrl.experiments.evaluator import (
+    batch_run_evaluation_episodes,
+    run_evaluation_episodes,
+)
 
 
 @pytest.mark.parametrize("episodic", [False, True])

--- a/tests/agents_tests/test_trpo.py
+++ b/tests/agents_tests/test_trpo.py
@@ -10,13 +10,19 @@ from torch import nn
 import pfrl
 from pfrl.agents import trpo
 from pfrl.envs.abc import ABC
-from pfrl.experiments.evaluator import batch_run_evaluation_episodes
-from pfrl.experiments.evaluator import run_evaluation_episodes
-from pfrl.experiments import train_agent_batch_with_evaluation
-from pfrl.experiments import train_agent_with_evaluation
+from pfrl.experiments import (
+    train_agent_batch_with_evaluation,
+    train_agent_with_evaluation,
+)
+from pfrl.experiments.evaluator import (
+    batch_run_evaluation_episodes,
+    run_evaluation_episodes,
+)
 from pfrl.nn import RecurrentSequential
-from pfrl.policies import SoftmaxCategoricalHead
-from pfrl.policies import GaussianHeadWithStateIndependentCovariance
+from pfrl.policies import (
+    GaussianHeadWithStateIndependentCovariance,
+    SoftmaxCategoricalHead,
+)
 from pfrl.testing import torch_assert_allclose
 
 

--- a/tests/collections_tests/test_prioritized.py
+++ b/tests/collections_tests/test_prioritized.py
@@ -1,7 +1,7 @@
+import random
 import unittest
 
 import numpy as np
-import random
 import pytest
 
 from pfrl.collections import prioritized

--- a/tests/experiments_tests/test_prepare_output_dir.py
+++ b/tests/experiments_tests/test_prepare_output_dir.py
@@ -2,10 +2,11 @@ import contextlib
 import itertools
 import json
 import os
-import pytest
 import subprocess
 import sys
 import tempfile
+
+import pytest
 
 import pfrl
 

--- a/tests/experiments_tests/test_train_agent_async.py
+++ b/tests/experiments_tests/test_train_agent_async.py
@@ -1,10 +1,10 @@
-import torch.multiprocessing as mp
 import os
 import tempfile
 import unittest
 from unittest import mock
 
 import pytest
+import torch.multiprocessing as mp
 
 import pfrl
 from pfrl.experiments.train_agent_async import train_loop

--- a/tests/explorers_tests/test_boltzmann.py
+++ b/tests/explorers_tests/test_boltzmann.py
@@ -1,7 +1,7 @@
 import unittest
 
-import torch
 import numpy as np
+import torch
 
 import pfrl
 

--- a/tests/functions_tests/test_lower_triangular_matrix.py
+++ b/tests/functions_tests/test_lower_triangular_matrix.py
@@ -1,7 +1,7 @@
-import torch
-
 import numpy as np
 import pytest
+import torch
+
 from pfrl.functions.lower_triangular_matrix import lower_triangular_matrix
 
 

--- a/tests/nn_tests/test_mlp_bn.py
+++ b/tests/nn_tests/test_mlp_bn.py
@@ -1,10 +1,10 @@
-import torch
+import unittest
+
 import numpy as np
+import pytest
+import torch
 
 import pfrl
-
-import pytest
-import unittest
 
 assertions = unittest.TestCase("__init__")
 

--- a/tests/nn_tests/test_noisy_chain.py
+++ b/tests/nn_tests/test_noisy_chain.py
@@ -1,6 +1,7 @@
-import torch
-import numpy
 import unittest
+
+import numpy
+import torch
 
 from pfrl.nn import to_factorized_noisy
 

--- a/tests/nn_tests/test_noisy_linear.py
+++ b/tests/nn_tests/test_noisy_linear.py
@@ -1,9 +1,8 @@
 import numpy
+import pytest
+import torch
 
 from pfrl.nn import noisy_linear
-
-import torch
-import pytest
 
 
 @pytest.mark.parametrize("bias", [False, True])

--- a/tests/nn_tests/test_recurrent_branched.py
+++ b/tests/nn_tests/test_recurrent_branched.py
@@ -4,13 +4,14 @@ import pytest
 import torch
 from torch import nn
 
-from pfrl.nn import RecurrentBranched
-from pfrl.nn import RecurrentSequential
-from pfrl.utils.recurrent import mask_recurrent_state_at
-from pfrl.utils.recurrent import get_recurrent_state_at
-from pfrl.utils.recurrent import concatenate_recurrent_states
-from pfrl.utils.recurrent import one_step_forward
+from pfrl.nn import RecurrentBranched, RecurrentSequential
 from pfrl.testing import torch_assert_allclose
+from pfrl.utils.recurrent import (
+    concatenate_recurrent_states,
+    get_recurrent_state_at,
+    mask_recurrent_state_at,
+    one_step_forward,
+)
 
 
 class TestRecurrentBranched(unittest.TestCase):

--- a/tests/nn_tests/test_recurrent_sequential.py
+++ b/tests/nn_tests/test_recurrent_sequential.py
@@ -2,13 +2,11 @@ import unittest
 
 import pytest
 import torch
-from torch import nn
 import torch.nn.functional as F
+from torch import nn
 
-from pfrl.nn import RecurrentSequential
-
+from pfrl.nn import Lambda, RecurrentSequential
 from pfrl.testing import torch_assert_allclose
-from pfrl.nn import Lambda
 
 
 def _step_lstm(lstm, x, state):

--- a/tests/q_functions_tests/basetest_state_action_q_function.py
+++ b/tests/q_functions_tests/basetest_state_action_q_function.py
@@ -1,6 +1,6 @@
 import unittest
-import numpy as np
 
+import numpy as np
 import torch
 
 assertions = unittest.TestCase("__init__")

--- a/tests/q_functions_tests/test_state_action_q_function.py
+++ b/tests/q_functions_tests/test_state_action_q_function.py
@@ -1,10 +1,10 @@
-import torch.nn.functional as F
+import unittest
 
 import basetest_state_action_q_function as base
-import pfrl
-
 import pytest
-import unittest
+import torch.nn.functional as F
+
+import pfrl
 
 assertions = unittest.TestCase("__init__")
 

--- a/tests/replay_buffers_test/test_replay_buffer.py
+++ b/tests/replay_buffers_test/test_replay_buffer.py
@@ -6,10 +6,9 @@ import unittest
 
 import numpy as np
 import pytest
-
-from pfrl import replay_buffers
-from pfrl import replay_buffer
 import torch
+
+from pfrl import replay_buffer, replay_buffers
 
 
 @pytest.mark.parametrize("capacity", [100, None])

--- a/tests/utils_tests/test_batch_states.py
+++ b/tests/utils_tests/test_batch_states.py
@@ -1,10 +1,10 @@
 import unittest
 
 import numpy as np
+import pytest
+import torch
 
 import pfrl
-import torch
-import pytest
 
 
 @pytest.mark.skip

--- a/tests/utils_tests/test_clip_l2_grad_norm.py
+++ b/tests/utils_tests/test_clip_l2_grad_norm.py
@@ -1,5 +1,5 @@
-from logging import getLogger
 import timeit
+from logging import getLogger
 
 import numpy as np
 import pytest

--- a/tests/utils_tests/test_copy_param.py
+++ b/tests/utils_tests/test_copy_param.py
@@ -1,11 +1,11 @@
 import unittest
 
+import numpy as np
 import torch
 import torch.nn as nn
-import numpy as np
 
-from pfrl.utils import copy_param
 from pfrl.testing import torch_assert_allclose
+from pfrl.utils import copy_param
 
 
 class TestCopyParam(unittest.TestCase):

--- a/tests/utils_tests/test_mode_of_distribution.py
+++ b/tests/utils_tests/test_mode_of_distribution.py
@@ -2,8 +2,8 @@ import math
 
 import torch
 
-from pfrl.utils.mode_of_distribution import mode_of_distribution
 from pfrl.testing import torch_assert_allclose
+from pfrl.utils.mode_of_distribution import mode_of_distribution
 
 
 def test_transform():

--- a/tests/utils_tests/test_random_seed.py
+++ b/tests/utils_tests/test_random_seed.py
@@ -1,9 +1,10 @@
 import random
 import unittest
 
-import pfrl
-import torch
 import pytest
+import torch
+
+import pfrl
 
 
 class TestSetRandomSeed(unittest.TestCase):

--- a/tests/utils_tests/test_recurrent.py
+++ b/tests/utils_tests/test_recurrent.py
@@ -4,10 +4,12 @@ import pytest
 import torch
 from torch import nn
 
-from pfrl.utils.recurrent import get_recurrent_state_at
-from pfrl.utils.recurrent import mask_recurrent_state_at
-from pfrl.utils.recurrent import concatenate_recurrent_states
 from pfrl.testing import torch_assert_allclose
+from pfrl.utils.recurrent import (
+    concatenate_recurrent_states,
+    get_recurrent_state_at,
+    mask_recurrent_state_at,
+)
 
 
 class TestRecurrentStateFunctions(unittest.TestCase):

--- a/tests/utils_tests/test_stoppable_thread.py
+++ b/tests/utils_tests/test_stoppable_thread.py
@@ -1,6 +1,6 @@
+import threading
 import unittest
 
-import threading
 from pfrl.utils import StoppableThread
 
 

--- a/tests/wrappers_tests/test_atari_wrappers.py
+++ b/tests/wrappers_tests/test_atari_wrappers.py
@@ -9,9 +9,7 @@ import gym.spaces
 import numpy as np
 import pytest
 
-from pfrl.wrappers.atari_wrappers import FrameStack
-from pfrl.wrappers.atari_wrappers import LazyFrames
-from pfrl.wrappers.atari_wrappers import ScaledFloatFrame
+from pfrl.wrappers.atari_wrappers import FrameStack, LazyFrames, ScaledFloatFrame
 
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.float32])

--- a/tests/wrappers_tests/test_monitor.py
+++ b/tests/wrappers_tests/test_monitor.py
@@ -3,8 +3,8 @@ import shutil
 import tempfile
 
 import gym
-from gym.wrappers import TimeLimit
 import pytest
+from gym.wrappers import TimeLimit
 
 import pfrl
 

--- a/tests/wrappers_tests/test_render.py
+++ b/tests/wrappers_tests/test_render.py
@@ -1,4 +1,5 @@
 from unittest import mock
+
 import pytest
 
 import pfrl

--- a/tests/wrappers_tests/test_vector_frame_stack.py
+++ b/tests/wrappers_tests/test_vector_frame_stack.py
@@ -8,10 +8,8 @@ import numpy as np
 import pytest
 
 import pfrl
-from pfrl.wrappers.atari_wrappers import FrameStack
-from pfrl.wrappers.atari_wrappers import LazyFrames
-from pfrl.wrappers.vector_frame_stack import VectorEnvWrapper
-from pfrl.wrappers.vector_frame_stack import VectorFrameStack
+from pfrl.wrappers.atari_wrappers import FrameStack, LazyFrames
+from pfrl.wrappers.vector_frame_stack import VectorEnvWrapper, VectorFrameStack
 
 
 class TestVectorEnvWrapper(unittest.TestCase):


### PR DESCRIPTION
Resolves #53 

- Apply isort
- Run isort in CI
- Add config so that isort is black-compatible (see https://black.readthedocs.io/en/stable/compatible_configs.html#isort)
- Fix some import errors that depends on import order