### PR TITLE
Add `step_hooks` and `optimizer_step_hooks` to actor-learner

### DIFF
--- a/pfrl/agents/dqn.py
+++ b/pfrl/agents/dqn.py
@@ -640,7 +640,7 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         exception_event: mp.synchronize.Event,
         n_updates: Optional[int] = None,
         step_hooks: List[Callable[[None, agent.Agent, int], Any]] = [],
-        optimizer_step_hooks: List[Callable[[None, agent.Agent, int], Any]] = []
+        optimizer_step_hooks: List[Callable[[None, agent.Agent, int], Any]] = [],
     ) -> None:
         try:
             update_counter = 0
@@ -719,7 +719,7 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         n_updates: Optional[int] = None,
         actor_update_interval: int = 8,
         step_hooks: List[Callable[[None, agent.Agent, int], Any]] = [],
-        optimizer_step_hooks: List[Callable[[None, agent.Agent, int], Any]] = []
+        optimizer_step_hooks: List[Callable[[None, agent.Agent, int], Any]] = [],
     ):
         if update_counter is None:
             update_counter = mp.Value(ctypes.c_ulong)

--- a/pfrl/agents/dqn.py
+++ b/pfrl/agents/dqn.py
@@ -639,8 +639,8 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         stop_event: mp.synchronize.Event,
         exception_event: mp.synchronize.Event,
         n_updates: Optional[int] = None,
-        step_hooks: List[Callable[None, agent.Agent, int], Any] = [],
-        optimizer_step_hooks: List[Callable[None, agent.Agent, int], Any] = []
+        step_hooks: List[Callable[[None, agent.Agent, int], Any]] = [],
+        optimizer_step_hooks: List[Callable[[None, agent.Agent, int], Any]] = []
     ) -> None:
         try:
             update_counter = 0
@@ -718,8 +718,8 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         update_counter: Optional[Any] = None,
         n_updates: Optional[int] = None,
         actor_update_interval: int = 8,
-        step_hooks: List[Callable[None, agent.Agent, int], Any] = [],
-        optimizer_step_hooks: List[Callable[None, agent.Agent, int], Any] = []
+        step_hooks: List[Callable[[None, agent.Agent, int], Any]] = [],
+        optimizer_step_hooks: List[Callable[[None, agent.Agent, int], Any]] = []
     ):
         if update_counter is None:
             update_counter = mp.Value(ctypes.c_ulong)

--- a/pfrl/agents/dqn.py
+++ b/pfrl/agents/dqn.py
@@ -13,7 +13,6 @@ import torch.nn.functional as F
 
 import pfrl
 from pfrl import agent
-from pfrl import env
 from pfrl.action_value import ActionValue
 from pfrl.explorer import Explorer
 from pfrl.replay_buffer import (
@@ -640,8 +639,8 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         stop_event: mp.synchronize.Event,
         exception_event: mp.synchronize.Event,
         n_updates: Optional[int] = None,
-        step_hooks: List[Callable[[Optional[env.Env], agent.Agent, int], Any]] = [],
-        optimizer_step_hooks: List[Callable[[Optional[env.Env], agent.Agent, int], Any]] = []
+        step_hooks: List[Callable[None, agent.Agent, int], Any] = [],
+        optimizer_step_hooks: List[Callable[None, agent.Agent, int], Any] = []
     ) -> None:
         try:
             update_counter = 0
@@ -719,8 +718,8 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         update_counter: Optional[Any] = None,
         n_updates: Optional[int] = None,
         actor_update_interval: int = 8,
-        step_hooks: List[Callable[[Optional[env.Env], agent.Agent, int], Any]] = [],
-        optimizer_step_hooks: List[Callable[[Optional[env.Env], agent.Agent, int], Any]] = []
+        step_hooks: List[Callable[None, agent.Agent, int], Any] = [],
+        optimizer_step_hooks: List[Callable[None, agent.Agent, int], Any] = []
     ):
         if update_counter is None:
             update_counter = mp.Value(ctypes.c_ulong)

--- a/tests/agents_tests/basetest_training.py
+++ b/tests/agents_tests/basetest_training.py
@@ -2,6 +2,7 @@ import logging
 import os
 import tempfile
 import pytest
+import mock
 
 import numpy as np
 
@@ -185,6 +186,9 @@ class _TestActorLearnerTrainingMixin(object):
             env, _ = self.make_env_and_successful_return(test=test)
             return env
 
+        step_hook = mock.Mock()
+        optimizer_step_hook = mock.Mock()
+
         # Train
         if steps > 0:
             (
@@ -192,7 +196,8 @@ class _TestActorLearnerTrainingMixin(object):
                 learner,
                 poller,
                 exception_event,
-            ) = agent.setup_actor_learner_training(n_actors=2)
+            ) = agent.setup_actor_learner_training(n_actors=2, step_hooks=[step_hook],
+                                                   optimizer_step_hooks=[optimizer_step_hook])
 
             poller.start()
             learner.start()
@@ -225,6 +230,26 @@ class _TestActorLearnerTrainingMixin(object):
         # we can only test the range
         assert agent.cumulative_steps > 0
         assert agent.cumulative_steps <= steps + 1
+
+        # Unlike the non-actor-learner cases, the step_hooks and
+        # optimizer_step_hooks are only called when the update happens
+        # when we do a fast test, the update may not be triggered due to
+        # limited amount of experience, the call_count can be 0 in such case
+        assert step_hook.call_count >= 0
+        assert step_hook.call_count <= steps / agent.update_interval
+        assert optimizer_step_hook.call_count == step_hook.call_count
+
+        for i, call in enumerate(step_hook.call_args_list):
+            args, kwargs = call
+            assert args[0] is None
+            assert args[1] is agent
+            assert args[2] == (i + 1) * agent.update_interval
+
+        for i, call in enumerate(optimizer_step_hook.call_args_list):
+            args, kwargs = call
+            assert args[0] is None
+            assert args[1] is agent
+            assert args[2] == i + 1
 
         successful_path = os.path.join(self.tmpdir, "successful")
         finished_path = os.path.join(self.tmpdir, "{}_finish".format(steps))

--- a/tests/agents_tests/basetest_training.py
+++ b/tests/agents_tests/basetest_training.py
@@ -200,8 +200,11 @@ class _TestActorLearnerTrainingMixin(object):
                 learner,
                 poller,
                 exception_event,
-            ) = agent.setup_actor_learner_training(n_actors=2, step_hooks=[step_hook],
-                                                   optimizer_step_hooks=[optimizer_step_hook])
+            ) = agent.setup_actor_learner_training(
+                n_actors=2,
+                step_hooks=[step_hook],
+                optimizer_step_hooks=[optimizer_step_hook],
+            )
 
             poller.start()
             learner.start()

--- a/tests/agents_tests/basetest_training.py
+++ b/tests/agents_tests/basetest_training.py
@@ -1,7 +1,7 @@
 import logging
 import os
 import tempfile
-import mock
+from unittest import mock
 
 import numpy as np
 import pytest


### PR DESCRIPTION
Step_hooks can be registered by users to perform operations like lr decay
after each step.
However, in the current actor-learner implementation, the step_hooks are called
from the actor side, while variables like lr are on the learner side.
Such difference disables the lr decay by step_hooks.

This PR adds hooks to the learner side to re-enable the step_hooks
related to learner.
Since we can specify both steps and n_updates for the learner, we add
two hooks to handle both of them respectively.
1. A `step_hooks` that takes the `effective_timesteps` as args and
   performs the same way as the original `step_hooks`.
2. A `optimizer_step_hooks` takes the `optimizer_step` instead of the
   `effective_timesteps` as args.