### PR TITLE
Adds env_stats to record_tb_stats

### DIFF
--- a/pfrl/experiments/evaluator.py
+++ b/pfrl/experiments/evaluator.py
@@ -300,11 +300,14 @@ def create_tb_writer(outdir):
     return tb_writer
 
 
-def record_tb_stats(summary_writer, agent_stats, eval_stats, t):
+def record_tb_stats(summary_writer, agent_stats, eval_stats, env_stats, t):
     cur_time = time.time()
 
     for stat, value in agent_stats:
         summary_writer.add_scalar("agent/" + stat, value, t, cur_time)
+
+    for stat, value in env_stats:
+        summary_writer.add_scalar("env/" + stat, value, t, cur_time)
 
     for stat in ("mean", "median", "max", "min", "stdev"):
         value = eval_stats[stat]
@@ -443,7 +446,7 @@ class Evaluator(object):
         record_stats(self.outdir, values)
 
         if self.use_tensorboard:
-            record_tb_stats(self.tb_writer, agent_stats, eval_stats, t)
+            record_tb_stats(self.tb_writer, agent_stats, eval_stats, env_stats, t)
 
         if mean > self.max_score:
             self.logger.info("The best score is updated %s -> %s", self.max_score, mean)
@@ -561,7 +564,7 @@ class AsyncEvaluator(object):
         record_stats(self.outdir, values)
 
         if self.use_tensorboard:
-            record_tb_stats(self.tb_writer, agent_stats, eval_stats, t)
+            record_tb_stats(self.tb_writer, agent_stats, eval_stats, env_stats, t)
 
         with self._max_score.get_lock():
             if mean > self._max_score.value:


### PR DESCRIPTION
Currently, environment statistics are not being incorporated into the tensorboard output.

I modified `train_dqn_ale.py` by adding a dummy wrapper:

```
import gym
class ComputeSuccessRate(gym.Wrapper):
    def __init__(self, env):
        super().__init__(env)
        self.success_record = []

    def reset(self):
        return self.env.reset()

    def step(self, action):
        obs, r, done, info = self.env.step(action)
        return obs, r, done, info

    def get_statistics(self):
        return [("success_rate", 0.75)]

    def clear_statistics(self):
        self.success_record = []
```
The wrapper itself is useless, but it returns environment statistics. I've confirmed they appear in tensorboard when I run an experiment with`use_tensorboard`:

![image](https://user-images.githubusercontent.com/10005453/100072326-73980900-2e7f-11eb-91f4-f4b325c0eeb2.png)



