### PR TITLE
Fixes flake errors 

### DIFF
--- a/examples/atari/reproduction/a3c/train_a3c.py
+++ b/examples/atari/reproduction/a3c/train_a3c.py
@@ -2,17 +2,17 @@ import argparse
 import os
 
 # Prevent numpy from using multiple threads
-os.environ["OMP_NUM_THREADS"] = "1"  # NOQA
+os.environ["OMP_NUM_THREADS"] = "1"
 
-import numpy as np
-from torch import nn
+import numpy as np  # NOQA:E402
+from torch import nn  # NOQA:E402
 
-import pfrl
-from pfrl import experiments, utils
-from pfrl.agents import a3c
-from pfrl.optimizers import SharedRMSpropEpsInsideSqrt
-from pfrl.policies import SoftmaxCategoricalHead
-from pfrl.wrappers import atari_wrappers
+import pfrl  # NOQA:E402
+from pfrl import experiments, utils  # NOQA:E402
+from pfrl.agents import a3c  # NOQA:E402
+from pfrl.optimizers import SharedRMSpropEpsInsideSqrt  # NOQA:E402
+from pfrl.policies import SoftmaxCategoricalHead  # NOQA:E402
+from pfrl.wrappers import atari_wrappers  # NOQA:E402
 
 
 def main():

--- a/examples/atari/train_acer_ale.py
+++ b/examples/atari/train_acer_ale.py
@@ -2,20 +2,20 @@ import argparse
 import os
 
 # Prevent numpy from using multiple threads
-os.environ["OMP_NUM_THREADS"] = "1"  # NOQA
+os.environ["OMP_NUM_THREADS"] = "1"
 
-import gym
-import gym.wrappers
-import numpy as np
-from torch import nn
+import gym  # NOQA:E402
+import gym.wrappers  # NOQA:E402
+import numpy as np  # NOQA:E402
+from torch import nn  # NOQA:E402
 
-import pfrl
-from pfrl import experiments, utils
-from pfrl.agents import acer
-from pfrl.policies import SoftmaxCategoricalHead
-from pfrl.q_functions import DiscreteActionValueHead
-from pfrl.replay_buffers import EpisodicReplayBuffer
-from pfrl.wrappers import atari_wrappers
+import pfrl  # NOQA:E402
+from pfrl import experiments, utils  # NOQA:E402
+from pfrl.agents import acer  # NOQA:E402
+from pfrl.policies import SoftmaxCategoricalHead  # NOQA:E402
+from pfrl.q_functions import DiscreteActionValueHead  # NOQA:E402
+from pfrl.replay_buffers import EpisodicReplayBuffer  # NOQA:E402
+from pfrl.wrappers import atari_wrappers  # NOQA:E402
 
 
 def main():

--- a/pfrl/nn/mlp.py
+++ b/pfrl/nn/mlp.py
@@ -31,6 +31,6 @@ class MLP(nn.Module):
     def forward(self, x):
         h = x
         if self.hidden_sizes:
-            for l in self.hidden_layers:
-                h = self.nonlinearity(l(h))
+            for layer in self.hidden_layers:
+                h = self.nonlinearity(layer(h))
         return self.output(h)

--- a/pfrl/nn/mlp_bn.py
+++ b/pfrl/nn/mlp_bn.py
@@ -73,8 +73,8 @@ class MLPBN(nn.Module):
         if self.normalize_input:
             h = self.input_bn(h)
         if self.hidden_sizes:
-            for l in self.hidden_layers:
-                h = self.nonlinearity(l(h))
+            for layer in self.hidden_layers:
+                h = self.nonlinearity(layer(h))
         h = self.output(h)
         if self.normalize_output:
             h = self.output_bn(h)

--- a/pfrl/q_functions/dueling_dqn.py
+++ b/pfrl/q_functions/dueling_dqn.py
@@ -45,8 +45,8 @@ class DuelingDQN(nn.Module, StateQFunction):
 
     def forward(self, x):
         h = x
-        for l in self.conv_layers:
-            h = self.activation(l(h))
+        for layer in self.conv_layers:
+            h = self.activation(layer(h))
 
         # Advantage
         batch_size = x.shape[0]
@@ -105,8 +105,8 @@ class DistributionalDuelingDQN(nn.Module, StateQFunction):
 
     def forward(self, x):
         h = x
-        for l in self.conv_layers:
-            h = self.activation(l(h))
+        for layer in self.conv_layers:
+            h = self.activation(layer(h))
 
         # Advantage
         batch_size = x.shape[0]


### PR DESCRIPTION
Addresses  #99 and #100

A flake update changed the behavior of ignoring E402 ([ref](https://gitlab.com/pycqa/flake8/-/issues/638)). This PR applies the recommended fix and also handles E741s with a variable rename. 