### PR TITLE
Evaluation during training episodes

### DIFF
--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -221,6 +221,7 @@ def main():
             outdir=args.outdir,
             eval_env=eval_env,
             train_max_episode_len=timestep_limit,
+            eval_during_episode=True,
         )
     else:
         # using impala mode when given num of envs

--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -211,6 +211,12 @@ def main():
 
     elif not args.actor_learner:
 
+        print(
+            "WARNING: Since https://github.com/pfnet/pfrl/pull/112 we have started"
+            " setting `eval_during_episode=True` in this script, which affects the"
+            " timings of evaluation phases."
+        )
+
         experiments.train_agent_with_evaluation(
             agent=agent,
             env=env,

--- a/pfrl/experiments/train_agent.py
+++ b/pfrl/experiments/train_agent.py
@@ -33,6 +33,7 @@ def train_agent(
     successful_score=None,
     step_hooks=(),
     evaluation_hooks=(),
+    eval_during_episode=False,
     logger=None,
 ):
 
@@ -66,7 +67,9 @@ def train_agent(
             for hook in step_hooks:
                 hook(env, agent, t)
 
-            if done or reset or t == steps:
+            episode_end = done or reset or t == steps
+
+            if episode_end:
                 logger.info(
                     "outdir:%s step:%s episode:%s R:%s",
                     outdir,
@@ -76,26 +79,27 @@ def train_agent(
                 )
                 stats = agent.get_statistics()
                 logger.info("statistics:%s", stats)
-                if evaluator is not None:
-                    eval_score = evaluator.evaluate_if_necessary(
-                        t=t, episodes=episode_idx + 1
-                    )
-                    if eval_score is not None:
-                        eval_stats = dict(stats)
-                        eval_stats["eval_score"] = eval_score
-                        eval_stats_history.append(eval_stats)
-                        for hook in evaluation_hooks:
-                            hook(env, agent, evaluator, t, eval_score)
-                    if (
-                        successful_score is not None
-                        and evaluator.max_score >= successful_score
-                    ):
-                        break
+                episode_idx += 1
+
+            if evaluator is not None and (episode_end or eval_during_episode):
+                eval_score = evaluator.evaluate_if_necessary(t=t, episodes=episode_idx)
+                if eval_score is not None:
+                    eval_stats = dict(agent.get_statistics())
+                    eval_stats["eval_score"] = eval_score
+                    eval_stats_history.append(eval_stats)
+                    for hook in evaluation_hooks:
+                        hook(env, agent, evaluator, t, eval_score)
+                if (
+                    successful_score is not None
+                    and evaluator.max_score >= successful_score
+                ):
+                    break
+
+            if episode_end:
                 if t == steps:
                     break
                 # Start a new episode
                 episode_r = 0
-                episode_idx += 1
                 episode_len = 0
                 obs = env.reset()
             if checkpoint_freq and t % checkpoint_freq == 0:
@@ -130,6 +134,7 @@ def train_agent_with_evaluation(
     evaluation_hooks=(),
     save_best_so_far_agent=True,
     use_tensorboard=False,
+    eval_during_episode=False,
     logger=None,
 ):
     """Train an agent while periodically evaluating it.
@@ -160,6 +165,8 @@ def train_agent_with_evaluation(
             phase, if the score (= mean return of evaluation episodes) exceeds
             the best-so-far score, the current agent is saved.
         use_tensorboard (bool): Additionally log eval stats to tensorboard
+        eval_during_episode (bool): Allow running evaluation during training episodes.
+            This should be enabled only when `env` and `eval_env` are independent.
         logger (logging.Logger): Logger used in this function.
     Returns:
         agent: Trained agent.
@@ -171,6 +178,10 @@ def train_agent_with_evaluation(
     os.makedirs(outdir, exist_ok=True)
 
     if eval_env is None:
+        assert not eval_during_episode, (
+            "To run evaluation during training episodes, you need to specify `eval_env`"
+            " that is independent from `env`."
+        )
         eval_env = env
 
     if eval_max_episode_len is None:
@@ -202,6 +213,7 @@ def train_agent_with_evaluation(
         successful_score=successful_score,
         step_hooks=step_hooks,
         evaluation_hooks=evaluation_hooks,
+        eval_during_episode=eval_during_episode,
         logger=logger,
     )
 

--- a/tests/experiments_tests/test_train_agent.py
+++ b/tests/experiments_tests/test_train_agent.py
@@ -2,6 +2,8 @@ import tempfile
 import unittest
 from unittest import mock
 
+import pytest
+
 import pfrl
 
 
@@ -116,7 +118,11 @@ class TestTrainAgent(unittest.TestCase):
             ("n_updates", 8),
             ("rlen", 1),
         ]
-        agent.get_statistics.side_effect = [dummy_stats] * n_resets
+        # `agent.get_statistics` is called:
+        #   - when an episode ends
+        #   - when evaluation happens
+        # Here, `n_resets` episodes end and 1 evaluation happens.
+        agent.get_statistics.side_effect = [dummy_stats] * (n_resets + 1)
 
         evaluator = mock.Mock()
         # evaluator.evaluate_if_necessary is invoked after episode ends
@@ -167,3 +173,48 @@ class TestTrainAgent(unittest.TestCase):
         self.assertIs(args[2], evaluator)
         self.assertIs(args[3], 5)
         self.assertIs(args[4], 42)
+
+
+@pytest.mark.parametrize("eval_during_episode", [False, True])
+def test_eval_during_episode(eval_during_episode):
+
+    outdir = tempfile.mkdtemp()
+
+    agent = mock.MagicMock()
+    env = mock.Mock()
+    # Two episodes
+    env.reset.side_effect = [("state", 0)] * 2
+    env.step.side_effect = [
+        (("state", 1), 0, False, {}),
+        (("state", 2), 0, False, {}),
+        (("state", 3), -0.5, True, {}),
+        (("state", 4), 0, False, {}),
+        (("state", 5), 1, True, {}),
+    ]
+
+    evaluator = mock.Mock()
+    pfrl.experiments.train_agent(
+        agent=agent,
+        env=env,
+        steps=5,
+        outdir=outdir,
+        evaluator=evaluator,
+        eval_during_episode=eval_during_episode,
+    )
+
+    if eval_during_episode:
+        # Must be called every timestep
+        assert evaluator.evaluate_if_necessary.call_count == 5
+        for i, call in enumerate(evaluator.evaluate_if_necessary.call_args_list):
+            kwargs = call[1]
+            assert i + 1 == kwargs["t"]
+            assert kwargs["episodes"] == int(i >= 2) + int(i >= 4)
+    else:
+        # Must be called after every episode
+        assert evaluator.evaluate_if_necessary.call_count == 2
+        first_kwargs = evaluator.evaluate_if_necessary.call_args_list[0][1]
+        second_kwargs = evaluator.evaluate_if_necessary.call_args_list[1][1]
+        assert first_kwargs["t"] == 3
+        assert first_kwargs["episodes"] == 1
+        assert second_kwargs["t"] == 5
+        assert second_kwargs["episodes"] == 2


### PR DESCRIPTION
## Background

PFRL's `train_agent_with_evaluation` runs evaluation only when training episodes finish. This is good when `env` and `eval_env` are the same environment, e.g., the real-world robot setup or some external program that is hard to run multiple instances of. However, when you can make an `eval_env` instance that is independent from `env`, there is no good reason to wait until training episodes end.

In fact, `train_agent_batch` does not wait until episodes end because when there are multiple training envs waiting until all the episodes end is inefficient and the logic would be complicated.

The downside of waiting until episodes end is that actual evaluation intervals does not follow the value of `eval_interval`. Here is `scores.txt` of `python examples/gym/train_dqn_gym.py --env CartPole-v0 --gpu -1 --eval-n-runs 10 --eval-interval 1000 --steps 10000` of `master`. Look at the column of `steps`.

```
steps	episodes	elapsed	mean	median	stdev	max	min	average_q	average_loss	cumulative_steps	n_updates	rlen
1021	49	0.46405887603759766	8.9	9.0	0.8755950357709131	10.0	8.0	0.30439645	0.0225488511972468	1021	22	1021
2026	88	3.4596009254455566	195.9	200.0	12.965338406690355	200.0	159.0	0.7258416	0.002005111983162351	2026	1027	2026
3008	117	6.283432960510254	124.4	125.5	13.696714934611146	140.0	100.0	1.0374576	0.0035956327240273824	3008	2009	3008
4021	151	8.994767904281616	93.3	93.0	8.59004591890456	107.0	75.0	1.1364052	0.002998790842539165	4021	3022	4021
5025	176	11.687598943710327	82.6	83.5	3.687817782917155	87.0	75.0	1.3751132	0.003210274265729822	5025	4026	5025
6045	195	14.706429958343506	156.6	154.0	17.225304383699903	200.0	141.0	1.6338439	0.005055326806614175	6045	5046	6045
7081	208	17.660122871398926	134.6	135.0	4.501851470969102	141.0	127.0	1.7221845	0.005496036116965115	7081	6082	7081
8004	218	20.26002287864685	114.5	114.0	2.9533408577782247	119.0	111.0	1.7510117	0.004004615361336619	8004	7005	8004
9023	232	23.045633792877197	105.2	104.5	4.871686908385363	112.0	99.0	1.958236	0.004077585676568561	9023	8024	9023
10000	241	25.780963897705078	146.7	148.0	8.857514073122072	160.0	135.0	1.9815891	0.0058340844104532155	10000	9001	10000
```

This is annoying when you visualize training curves. I believe, when we can make independent env instances for training and evaluation, it is better to avoid this.

## What this PR does

- Add `eval_during_episode` option to `train_agent_with_evaluation` so that users can avoid such waiting and run evaluations on time even during training episodes
- Add tests for both `eval_during_episode=True` and `eval_during_episode=False`
- Use `eval_during_episode=True` in `examples/gym/train_dqn_gym.py` for illustration. As I wrote above, I believe this is a better choice in most cases, but this PR keeps it optional elsewhere.
- Due to the change in the logic, the number of calls of `agent.get_statistics` could change. This is why I made a small change to the existing test case.

Here are `scores.txt` of the same command after the change.
```
steps	episodes	elapsed	mean	median	stdev	max	min	average_q	average_loss	cumulative_steps	n_updates	rlen
1000	48	0.4554009437561035	10.2	9.5	2.2997584414213788	16.0	8.0	0.17600906	0.032559558749198914	1000	1	1000
2000	91	3.330997943878174	90.1	80.0	36.73160915493781	173.0	53.0	1.2416949	0.004746826794289518	2000	1001	2000
3000	123	6.097692251205444	97.7	97.0	5.696977756280567	108.0	92.0	1.6330086	0.00885181687597651	3000	2001	3000
4000	140	8.853048086166382	148.8	148.5	4.1041983924323695	155.0	143.0	1.9203513	0.007965251127025112	4000	3001	4000
5000	166	11.703951120376587	144.2	142.5	6.762642481555071	159.0	137.0	2.1411452	0.010642013618489727	5000	4001	5000
6000	184	14.453600883483887	48.0	46.5	6.236095644623235	63.0	41.0	2.08529	0.008300355058163405	6000	5001	6000
7000	198	17.330674171447754	177.9	173.5	20.206984491066997	200.0	155.0	2.1882925	0.009315705448389054	7000	6001	7000
8000	204	20.148621082305908	142.9	142.0	6.6907896893167	160.0	136.0	2.4848661	0.009241904776426963	8000	7001	8000
9000	213	22.904212951660156	111.5	112.0	2.9907264074877267	116.0	106.0	2.7800713	0.015680431808577852	9000	8001	9000
10000	223	25.65988802909851	120.8	121.5	3.011090610836324	125.0	116.0	3.0515478	0.018133082903223113	10000	9001	10000
```