### PR TITLE
Install filelock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ install_requires = [
     'gym>=0.9.7',
     'numpy>=1.10.4',
     'pillow',
+    'filelock',
 ]
 
 test_requires = [


### PR DESCRIPTION
This PR adds installation of filelock, which is imported but not listed
in the setup.py.

With current master:
```
>>> import pfrl
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tianqi/repository/pfrl/pfrl/__init__.py", line 3, in <module>
    from pfrl import agents  # NOQA
  File "/home/tianqi/repository/pfrl/pfrl/agents/__init__.py", line 1, in <module>
    from pfrl.agents.a2c import A2C  # NOQA
  File "/home/tianqi/repository/pfrl/pfrl/agents/a2c.py", line 7, in <module>
    from pfrl.utils import clip_l2_grad_norm_
  File "/home/tianqi/repository/pfrl/pfrl/utils/__init__.py", line 7, in <module>
    from pfrl.utils.pretrained_models import download_model  # NOQA
  File "/home/tianqi/repository/pfrl/pfrl/utils/pretrained_models.py", line 14, in <module>
    import filelock
ModuleNotFoundError: No module named 'filelock'
```