### PR TITLE
Use latest black

### DIFF
--- a/.pfnci/lint.sh
+++ b/.pfnci/lint.sh
@@ -2,8 +2,7 @@
 
 set -eux
 
-# Use latest black to apply https://github.com/psf/black/issues/1288
-pip3 install git+git://github.com/psf/black.git@88d12f88a97e5e4c8fd0d245df0a311e932fd1e1 flake8 mypy isort
+pip3 install black flake8 mypy isort
 
 black --diff --check pfrl tests examples
 isort --diff --check pfrl tests examples

--- a/examples/atari/reproduction/a3c/train_a3c.py
+++ b/examples/atari/reproduction/a3c/train_a3c.py
@@ -120,7 +120,10 @@ def main():
         nn.Linear(2592, 256),
         nn.ReLU(),
         pfrl.nn.Branched(
-            nn.Sequential(nn.Linear(256, n_actions), SoftmaxCategoricalHead(),),
+            nn.Sequential(
+                nn.Linear(256, n_actions),
+                SoftmaxCategoricalHead(),
+            ),
             nn.Linear(256, 1),
         ),
     )

--- a/examples/atari/reproduction/iqn/train_iqn.py
+++ b/examples/atari/reproduction/iqn/train_iqn.py
@@ -124,8 +124,15 @@ def main():
             nn.ReLU(),
             nn.Flatten(),
         ),
-        phi=nn.Sequential(pfrl.agents.iqn.CosineBasisLinear(64, 3136), nn.ReLU(),),
-        f=nn.Sequential(nn.Linear(3136, 512), nn.ReLU(), nn.Linear(512, n_actions),),
+        phi=nn.Sequential(
+            pfrl.agents.iqn.CosineBasisLinear(64, 3136),
+            nn.ReLU(),
+        ),
+        f=nn.Sequential(
+            nn.Linear(3136, 512),
+            nn.ReLU(),
+            nn.Linear(512, n_actions),
+        ),
     )
 
     # Use the same hyper parameters as https://arxiv.org/abs/1710.10044
@@ -175,7 +182,10 @@ def main():
 
     if args.demo:
         eval_stats = experiments.eval_performance(
-            env=eval_env, agent=agent, n_steps=args.eval_n_steps, n_episodes=None,
+            env=eval_env,
+            agent=agent,
+            n_steps=args.eval_n_steps,
+            n_episodes=None,
         )
         print(
             "n_steps: {} mean: {} median: {} stdev {}".format(

--- a/examples/atari/reproduction/rainbow/train_rainbow.py
+++ b/examples/atari/reproduction/rainbow/train_rainbow.py
@@ -110,7 +110,12 @@ def main():
     n_atoms = 51
     v_max = 10
     v_min = -10
-    q_func = DistributionalDuelingDQN(n_actions, n_atoms, v_min, v_max,)
+    q_func = DistributionalDuelingDQN(
+        n_actions,
+        n_atoms,
+        v_min,
+        v_max,
+    )
 
     # Noisy nets
     pnn.to_factorized_noisy(q_func, sigma_scale=args.noisy_net_sigma)

--- a/examples/atari/train_a2c_ale.py
+++ b/examples/atari/train_a2c_ale.py
@@ -136,12 +136,18 @@ def main():
         nn.Linear(2592, 256),
         nn.ReLU(),
         pfrl.nn.Branched(
-            nn.Sequential(nn.Linear(256, n_actions), SoftmaxCategoricalHead(),),
+            nn.Sequential(
+                nn.Linear(256, n_actions),
+                SoftmaxCategoricalHead(),
+            ),
             nn.Linear(256, 1),
         ),
     )
     optimizer = pfrl.optimizers.RMSpropEpsInsideSqrt(
-        model.parameters(), lr=args.lr, eps=args.rmsprop_epsilon, alpha=args.alpha,
+        model.parameters(),
+        lr=args.lr,
+        eps=args.rmsprop_epsilon,
+        alpha=args.alpha,
     )
 
     agent = a2c.A2C(

--- a/examples/atari/train_acer_ale.py
+++ b/examples/atari/train_acer_ale.py
@@ -105,8 +105,14 @@ def main():
     )
 
     head = acer.ACERDiscreteActionHead(
-        pi=nn.Sequential(nn.Linear(256, n_actions), SoftmaxCategoricalHead(),),
-        q=nn.Sequential(nn.Linear(256, n_actions), DiscreteActionValueHead(),),
+        pi=nn.Sequential(
+            nn.Linear(256, n_actions),
+            SoftmaxCategoricalHead(),
+        ),
+        q=nn.Sequential(
+            nn.Linear(256, n_actions),
+            DiscreteActionValueHead(),
+        ),
     )
 
     if args.use_lstm:

--- a/examples/atari/train_drqn_ale.py
+++ b/examples/atari/train_drqn_ale.py
@@ -275,7 +275,10 @@ def main():
 
     if args.demo:
         eval_stats = experiments.eval_performance(
-            env=eval_env, agent=agent, n_steps=None, n_episodes=args.demo_n_episodes,
+            env=eval_env,
+            agent=agent,
+            n_steps=None,
+            n_episodes=args.demo_n_episodes,
         )
         print(
             "n_runs: {} mean: {} median: {} stdev {}".format(

--- a/examples/grasping/train_dqn_batch_grasping.py
+++ b/examples/grasping/train_dqn_batch_grasping.py
@@ -53,7 +53,10 @@ class ObserveElapsedSteps(gym.Wrapper):
         self._max_steps = max_steps
         self._elapsed_steps = 0
         self.observation_space = gym.spaces.Tuple(
-            (env.observation_space, gym.spaces.Discrete(self._max_steps + 1),)
+            (
+                env.observation_space,
+                gym.spaces.Discrete(self._max_steps + 1),
+            )
         )
 
     def reset(self):

--- a/examples/optuna/optuna_dqn_obs1d.py
+++ b/examples/optuna/optuna_dqn_obs1d.py
@@ -222,7 +222,9 @@ def suggest(trial, steps):
         max(1e3, hyperparams["decay_steps"] // 2), rbuf_capacity
     )
     hyperparams["replay_start_size"] = trial.suggest_int(
-        "replay_start_size", min_replay_start_size, max_replay_start_size,
+        "replay_start_size",
+        min_replay_start_size,
+        max_replay_start_size,
     )
     # target_update_interval should be a multiple of update_interval
     hyperparams["update_interval"] = trial.suggest_int("update_interval", 1, 8)
@@ -239,7 +241,10 @@ def main():
 
     # training parameters
     parser.add_argument(
-        "--env", type=str, default="LunarLander-v2", help="OpenAI Gym Environment ID.",
+        "--env",
+        type=str,
+        default="LunarLander-v2",
+        help="OpenAI Gym Environment ID.",
     )
     parser.add_argument(
         "--outdir",
@@ -251,7 +256,10 @@ def main():
         ),
     )
     parser.add_argument(
-        "--seed", type=int, default=0, help="Random seed for randomizer.",
+        "--seed",
+        type=int,
+        default=0,
+        help="Random seed for randomizer.",
     )
     parser.add_argument(
         "--monitor",
@@ -289,7 +297,10 @@ def main():
         help="Frequency (in timesteps) of evaluation phase.",
     )
     parser.add_argument(
-        "--batch-size", type=int, default=64, help="Training batch size.",
+        "--batch-size",
+        type=int,
+        default=64,
+        help="Training batch size.",
     )
 
     # Optuna related args
@@ -361,7 +372,9 @@ def main():
             help="Setting percentile == 50.0 is equivalent to the MedianPruner.",
         )
         parser.add_argument(
-            "--n-startup-trials", type=int, default=5,
+            "--n-startup-trials",
+            type=int,
+            default=5,
         )
         parser.add_argument(
             "--n-warmup-steps",
@@ -417,7 +430,8 @@ def main():
         pruner = optuna.pruners.NopPruner()
     elif args.optuna_pruner == "ThresholdPruner":
         pruner = optuna.pruners.ThresholdPruner(
-            lower=args.lower, n_warmup_steps=args.n_warmup_steps,
+            lower=args.lower,
+            n_warmup_steps=args.n_warmup_steps,
         )
     elif args.optuna_pruner == "PercentilePruner":
         pruner = optuna.pruners.PercentilePruner(

--- a/examples/slimevolley/train_rainbow.py
+++ b/examples/slimevolley/train_rainbow.py
@@ -210,7 +210,10 @@ def main():
 
     if args.demo:
         eval_stats = experiments.eval_performance(
-            env=eval_env, agent=agent, n_steps=None, n_episodes=args.eval_n_episodes,
+            env=eval_env,
+            agent=agent,
+            n_steps=None,
+            n_episodes=args.eval_n_episodes,
         )
         print(
             "n_episodes: {} mean: {} median: {} stdev {}".format(

--- a/pfrl/action_value.py
+++ b/pfrl/action_value.py
@@ -174,7 +174,9 @@ class DistributionalDiscreteActionValue(ActionValue):
 
     def __getitem__(self, i):
         return DistributionalDiscreteActionValue(
-            self.q_dist[i], self.z_values, q_values_formatter=self.q_values_formatter,
+            self.q_dist[i],
+            self.z_values,
+            q_values_formatter=self.q_values_formatter,
         )
 
 
@@ -209,9 +211,11 @@ class QuantileDiscreteActionValue(DiscreteActionValue):
         ]
 
     def __repr__(self):
-        return "QuantileDiscreteActionValue greedy_actions:{} q_values:{}".format(  # NOQA
-            self.greedy_actions.detach().cpu().numpy(),
-            self.q_values_formatter(self.q_values.detach().cpu().numpy()),
+        return (
+            "QuantileDiscreteActionValue greedy_actions:{} q_values:{}".format(  # NOQA
+                self.greedy_actions.detach().cpu().numpy(),
+                self.q_values_formatter(self.q_values.detach().cpu().numpy()),
+            )
         )
 
     @property
@@ -220,7 +224,8 @@ class QuantileDiscreteActionValue(DiscreteActionValue):
 
     def __getitem__(self, i):
         return QuantileDiscreteActionValue(
-            quantiles=self.quantiles[i], q_values_formatter=self.q_values_formatter,
+            quantiles=self.quantiles[i],
+            q_values_formatter=self.q_values_formatter,
         )
 
 
@@ -276,7 +281,9 @@ class QuadraticActionValue(ActionValue):
     @lazy_property
     def max(self):
         if self.min_action is None and self.max_action is None:
-            return self.v.reshape(self.batch_size,)
+            return self.v.reshape(
+                self.batch_size,
+            )
         else:
             return self.evaluate_actions(self.greedy_actions)
 
@@ -288,7 +295,9 @@ class QuadraticActionValue(ActionValue):
                 torch.matmul(u_minus_mu[:, None, :], self.mat), u_minus_mu[:, :, None]
             )[:, 0, 0]
         )
-        return a + self.v.reshape(self.batch_size,)
+        return a + self.v.reshape(
+            self.batch_size,
+        )
 
     def compute_advantage(self, actions):
         return self.evaluate_actions(actions) - self.max

--- a/pfrl/agents/a3c.py
+++ b/pfrl/agents/a3c.py
@@ -168,7 +168,9 @@ class A3C(agent.AttributeSavingMixin, agent.AsyncAgent):
         )
         if self.recurrent:
             (batch_distrib, batch_v), _ = pack_and_forward(
-                self.model, [batch_obs], self.past_recurrent_state[self.t_start],
+                self.model,
+                [batch_obs],
+                self.past_recurrent_state[self.t_start],
             )
         else:
             batch_distrib, batch_v = self.model(batch_obs)

--- a/pfrl/agents/acer.py
+++ b/pfrl/agents/acer.py
@@ -188,13 +188,17 @@ def deepcopy_distribution(distrib):
     """
     if isinstance(distrib, torch.distributions.Independent):
         return torch.distributions.Independent(
-            deepcopy_distribution(distrib.base_dist), distrib.reinterpreted_batch_ndims,
+            deepcopy_distribution(distrib.base_dist),
+            distrib.reinterpreted_batch_ndims,
         )
     elif isinstance(distrib, torch.distributions.Categorical):
-        return torch.distributions.Categorical(logits=distrib.logits.clone().detach(),)
+        return torch.distributions.Categorical(
+            logits=distrib.logits.clone().detach(),
+        )
     elif isinstance(distrib, torch.distributions.Normal):
         return torch.distributions.Normal(
-            loc=distrib.loc.clone().detach(), scale=distrib.scale.clone().detach(),
+            loc=distrib.loc.clone().detach(),
+            scale=distrib.scale.clone().detach(),
         )
     else:
         raise NotImplementedError("{} is not supported by ACER".format(type(distrib)))
@@ -624,7 +628,9 @@ class ACER(agent.AttributeSavingMixin, agent.AsyncAgent):
                         (avg_action_distrib, _, _),
                         shared_recurrent_state,
                     ) = one_step_forward(
-                        self.shared_average_model, bs, shared_recurrent_state,
+                        self.shared_average_model,
+                        bs,
+                        shared_recurrent_state,
                     )
                 else:
                     avg_action_distrib, _, _ = self.shared_average_model(bs)
@@ -731,7 +737,9 @@ class ACER(agent.AttributeSavingMixin, agent.AsyncAgent):
                     (avg_action_distrib, _, _),
                     self.shared_recurrent_states,
                 ) = one_step_forward(
-                    self.shared_average_model, statevar, self.shared_recurrent_states,
+                    self.shared_average_model,
+                    statevar,
+                    self.shared_recurrent_states,
                 )
             else:
                 avg_action_distrib, _, _ = self.shared_average_model(statevar)
@@ -789,7 +797,10 @@ class ACER(agent.AttributeSavingMixin, agent.AsyncAgent):
         self.past_rewards[self.t - 1] = reward
         if self.process_idx == 0:
             self.logger.debug(
-                "t:%s r:%s a:%s", self.t, reward, self.last_action,
+                "t:%s r:%s a:%s",
+                self.t,
+                reward,
+                self.last_action,
             )
 
         if self.t - self.t_start == self.t_max or done or reset:

--- a/pfrl/agents/al.py
+++ b/pfrl/agents/al.py
@@ -27,7 +27,9 @@ class AL(dqn.DQN):
 
         if self.recurrent:
             qout, _ = pack_and_forward(
-                self.model, batch_state, exp_batch["recurrent_state"],
+                self.model,
+                batch_state,
+                exp_batch["recurrent_state"],
             )
         else:
             qout = self.model(batch_state)
@@ -42,7 +44,9 @@ class AL(dqn.DQN):
         with torch.no_grad():
             if self.recurrent:
                 target_qout, _ = pack_and_forward(
-                    self.target_model, batch_state, exp_batch["recurrent_state"],
+                    self.target_model,
+                    batch_state,
+                    exp_batch["recurrent_state"],
                 )
                 target_next_qout, _ = pack_and_forward(
                     self.target_model,
@@ -53,7 +57,9 @@ class AL(dqn.DQN):
                 target_qout = self.target_model(batch_state)
                 target_next_qout = self.target_model(batch_next_state)
 
-            next_q_max = target_next_qout.max.reshape(batch_size,)
+            next_q_max = target_next_qout.max.reshape(
+                batch_size,
+            )
 
             batch_rewards = exp_batch["reward"]
             batch_terminal = exp_batch["is_state_terminal"]

--- a/pfrl/agents/categorical_double_dqn.py
+++ b/pfrl/agents/categorical_double_dqn.py
@@ -24,7 +24,9 @@ class CategoricalDoubleDQN(categorical_dqn.CategoricalDQN):
                     exp_batch["next_recurrent_state"],
                 )
                 next_qout, _ = pack_and_forward(
-                    self.model, batch_next_state, exp_batch["next_recurrent_state"],
+                    self.model,
+                    batch_next_state,
+                    exp_batch["next_recurrent_state"],
                 )
             else:
                 target_next_qout = self.target_model(batch_next_state)

--- a/pfrl/agents/categorical_dqn.py
+++ b/pfrl/agents/categorical_dqn.py
@@ -117,7 +117,9 @@ class CategoricalDQN(dqn.DQN):
         batch_next_state = exp_batch["next_state"]
         if self.recurrent:
             target_next_qout, _ = pack_and_forward(
-                self.target_model, batch_next_state, exp_batch["next_recurrent_state"],
+                self.target_model,
+                batch_next_state,
+                exp_batch["next_recurrent_state"],
             )
         else:
             target_next_qout = self.target_model(batch_next_state)

--- a/pfrl/agents/double_dqn.py
+++ b/pfrl/agents/double_dqn.py
@@ -16,14 +16,18 @@ class DoubleDQN(dqn.DQN):
         with evaluating(self.model):
             if self.recurrent:
                 next_qout, _ = pack_and_forward(
-                    self.model, batch_next_state, exp_batch["next_recurrent_state"],
+                    self.model,
+                    batch_next_state,
+                    exp_batch["next_recurrent_state"],
                 )
             else:
                 next_qout = self.model(batch_next_state)
 
         if self.recurrent:
             target_next_qout, _ = pack_and_forward(
-                self.target_model, batch_next_state, exp_batch["next_recurrent_state"],
+                self.target_model,
+                batch_next_state,
+                exp_batch["next_recurrent_state"],
             )
         else:
             target_next_qout = self.target_model(batch_next_state)

--- a/pfrl/agents/double_pal.py
+++ b/pfrl/agents/double_pal.py
@@ -12,7 +12,9 @@ class DoublePAL(pal.PAL):
 
         if self.recurrent:
             qout, _ = pack_and_forward(
-                self.model, batch_state, exp_batch["recurrent_state"],
+                self.model,
+                batch_state,
+                exp_batch["recurrent_state"],
             )
         else:
             qout = self.model(batch_state)
@@ -26,10 +28,14 @@ class DoublePAL(pal.PAL):
             batch_next_state = exp_batch["next_state"]
             if self.recurrent:
                 next_qout, _ = pack_and_forward(
-                    self.model, batch_next_state, exp_batch["next_recurrent_state"],
+                    self.model,
+                    batch_next_state,
+                    exp_batch["next_recurrent_state"],
                 )
                 target_qout, _ = pack_and_forward(
-                    self.target_model, batch_state, exp_batch["recurrent_state"],
+                    self.target_model,
+                    batch_state,
+                    exp_batch["recurrent_state"],
                 )
                 target_next_qout, _ = pack_and_forward(
                     self.target_model,

--- a/pfrl/agents/dpp.py
+++ b/pfrl/agents/dpp.py
@@ -22,7 +22,9 @@ class AbstractDPP(DQN, metaclass=ABCMeta):
 
         if self.recurrent:
             target_next_qout, _ = pack_and_forward(
-                self.target_model, batch_next_state, exp_batch["next_recurrent_state"],
+                self.target_model,
+                batch_next_state,
+                exp_batch["next_recurrent_state"],
             )
         else:
             target_next_qout = self.target_model(batch_next_state)
@@ -42,7 +44,9 @@ class AbstractDPP(DQN, metaclass=ABCMeta):
 
         if self.recurrent:
             qout, _ = pack_and_forward(
-                self.model, batch_state, exp_batch["recurrent_state"],
+                self.model,
+                batch_state,
+                exp_batch["recurrent_state"],
             )
         else:
             qout = self.model(batch_state)
@@ -55,7 +59,9 @@ class AbstractDPP(DQN, metaclass=ABCMeta):
             # Compute target values
             if self.recurrent:
                 target_qout, _ = pack_and_forward(
-                    self.target_model, batch_state, exp_batch["recurrent_state"],
+                    self.target_model,
+                    batch_state,
+                    exp_batch["recurrent_state"],
                 )
             else:
                 target_qout = self.target_model(batch_state)

--- a/pfrl/agents/dqn.py
+++ b/pfrl/agents/dqn.py
@@ -90,7 +90,9 @@ def compute_weighted_value_loss(
         losses = F.smooth_l1_loss(y, t, reduction="none")
     else:
         losses = F.mse_loss(y, t, reduction="none") / 2
-    losses = losses.reshape(-1,)
+    losses = losses.reshape(
+        -1,
+    )
     weights = weights.to(losses.device)
     loss_sum = torch.sum(losses * weights)
     if batch_accumulator == "mean":
@@ -277,7 +279,10 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         return self._cumulative_steps
 
     def _setup_actor_learner_training(
-        self, n_actors: int, actor_update_interval: int, update_counter: Any,
+        self,
+        n_actors: int,
+        actor_update_interval: int,
+        update_counter: Any,
     ) -> Tuple[
         torch.nn.Module,
         Sequence[mp.connection.Connection],
@@ -383,7 +388,9 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
 
         if self.recurrent:
             target_next_qout, _ = pack_and_forward(
-                self.target_model, batch_next_state, exp_batch["next_recurrent_state"],
+                self.target_model,
+                batch_next_state,
+                exp_batch["next_recurrent_state"],
             )
         else:
             target_next_qout = self.target_model(batch_next_state)
@@ -485,7 +492,9 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         if self.training:
             batch_action = [
                 self.explorer.select_action(
-                    self.t, lambda: batch_argmax[i], action_value=batch_av[i : i + 1],
+                    self.t,
+                    lambda: batch_argmax[i],
+                    action_value=batch_av[i : i + 1],
                 )
                 for i in range(len(batch_obs))
             ]
@@ -541,10 +550,12 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         if self.recurrent:
             # Reset recurrent states when episodes end
             self.train_prev_recurrent_states = None
-            self.train_recurrent_states = _batch_reset_recurrent_states_when_episodes_end(  # NOQA
-                batch_done=batch_done,
-                batch_reset=batch_reset,
-                recurrent_states=self.train_recurrent_states,
+            self.train_recurrent_states = (
+                _batch_reset_recurrent_states_when_episodes_end(  # NOQA
+                    batch_done=batch_done,
+                    batch_reset=batch_reset,
+                    recurrent_states=self.train_recurrent_states,
+                )
             )
 
     def _batch_observe_eval(
@@ -556,10 +567,12 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
     ) -> None:
         if self.recurrent:
             # Reset recurrent states when episodes end
-            self.test_recurrent_states = _batch_reset_recurrent_states_when_episodes_end(  # NOQA
-                batch_done=batch_done,
-                batch_reset=batch_reset,
-                recurrent_states=self.test_recurrent_states,
+            self.test_recurrent_states = (
+                _batch_reset_recurrent_states_when_episodes_end(  # NOQA
+                    batch_done=batch_done,
+                    batch_reset=batch_reset,
+                    recurrent_states=self.test_recurrent_states,
+                )
             )
 
     def batch_observe(

--- a/pfrl/agents/iqn.py
+++ b/pfrl/agents/iqn.py
@@ -303,7 +303,9 @@ class IQN(dqn.DQN):
 
         if self.recurrent:
             target_next_tau2av, _ = pack_and_forward(
-                self.target_model, batch_next_state, exp_batch["next_recurrent_state"],
+                self.target_model,
+                batch_next_state,
+                exp_batch["next_recurrent_state"],
             )
         else:
             target_next_tau2av = self.target_model(batch_next_state)
@@ -348,7 +350,9 @@ class IQN(dqn.DQN):
         # (batch_size, n_actions, n_atoms)
         if self.recurrent:
             tau2av, _ = pack_and_forward(
-                self.model, batch_state, exp_batch["recurrent_state"],
+                self.model,
+                batch_state,
+                exp_batch["recurrent_state"],
             )
         else:
             tau2av = self.model(batch_state)

--- a/pfrl/agents/pal.py
+++ b/pfrl/agents/pal.py
@@ -27,7 +27,9 @@ class PAL(dqn.DQN):
 
         if self.recurrent:
             qout, _ = pack_and_forward(
-                self.model, batch_state, exp_batch["recurrent_state"],
+                self.model,
+                batch_state,
+                exp_batch["recurrent_state"],
             )
         else:
             qout = self.model(batch_state)
@@ -40,7 +42,9 @@ class PAL(dqn.DQN):
         with torch.no_grad():
             if self.recurrent:
                 target_qout, _ = pack_and_forward(
-                    self.target_model, batch_state, exp_batch["recurrent_state"],
+                    self.target_model,
+                    batch_state,
+                    exp_batch["recurrent_state"],
                 )
                 target_next_qout, _ = pack_and_forward(
                     self.target_model,

--- a/pfrl/agents/ppo.py
+++ b/pfrl/agents/ppo.py
@@ -54,7 +54,12 @@ def _add_advantage_and_value_target_to_episodes(episodes, gamma, lambd):
 
 
 def _add_log_prob_and_value_to_episodes_recurrent(
-    episodes, model, phi, batch_states, obs_normalizer, device,
+    episodes,
+    model,
+    phi,
+    batch_states,
+    obs_normalizer,
+    device,
 ):
     # Sort desc by lengths so that pack_sequence does not change the order
     episodes = sorted(episodes, key=len, reverse=True)
@@ -103,7 +108,12 @@ def _add_log_prob_and_value_to_episodes_recurrent(
 
 
 def _add_log_prob_and_value_to_episodes(
-    episodes, model, phi, batch_states, obs_normalizer, device,
+    episodes,
+    model,
+    phi,
+    batch_states,
+    obs_normalizer,
+    device,
 ):
 
     dataset = list(itertools.chain.from_iterable(episodes))
@@ -483,13 +493,19 @@ class PPO(agent.AttributeSavingMixin, agent.BatchAgent):
                 advs = (advs - mean_advs) / (std_advs + 1e-8)
 
             log_probs_old = torch.tensor(
-                [b["log_prob"] for b in batch], dtype=torch.float, device=device,
+                [b["log_prob"] for b in batch],
+                dtype=torch.float,
+                device=device,
             )
             vs_pred_old = torch.tensor(
-                [b["v_pred"] for b in batch], dtype=torch.float, device=device,
+                [b["v_pred"] for b in batch],
+                dtype=torch.float,
+                device=device,
             )
             vs_teacher = torch.tensor(
-                [b["v_teacher"] for b in batch], dtype=torch.float, device=device,
+                [b["v_teacher"] for b in batch],
+                dtype=torch.float,
+                device=device,
             )
             # Same shape as vs_pred: (batch_size, 1)
             vs_pred_old = vs_pred_old[..., None]
@@ -528,14 +544,17 @@ class PPO(agent.AttributeSavingMixin, agent.BatchAgent):
         seqs_states = []
         for ep in episodes:
             states = self.batch_states(
-                [transition["state"] for transition in ep], self.device, self.phi,
+                [transition["state"] for transition in ep],
+                self.device,
+                self.phi,
             )
             if self.obs_normalizer:
                 states = self.obs_normalizer(states, update=False)
             seqs_states.append(states)
 
         flat_actions = torch.tensor(
-            [transition["action"] for transition in flat_transitions], device=device,
+            [transition["action"] for transition in flat_transitions],
+            device=device,
         )
         flat_advs = torch.tensor(
             [transition["adv"] for transition in flat_transitions],
@@ -628,7 +647,9 @@ class PPO(agent.AttributeSavingMixin, agent.BatchAgent):
             loss_value_func = F.mse_loss(vs_pred, vs_teacher)
         else:
             clipped_vs_pred = _elementwise_clip(
-                vs_pred, vs_pred_old - self.clip_eps_vf, vs_pred_old + self.clip_eps_vf,
+                vs_pred,
+                vs_pred_old - self.clip_eps_vf,
+                vs_pred_old + self.clip_eps_vf,
             )
             loss_value_func = torch.mean(
                 torch.max(

--- a/pfrl/agents/trpo.py
+++ b/pfrl/agents/trpo.py
@@ -403,7 +403,9 @@ class TRPO(agent.AttributeSavingMixin, agent.BatchAgent):
             if self.obs_normalizer:
                 states = self.obs_normalizer(states, update=False)
             vs_teacher = torch.as_tensor(
-                [b["v_teacher"] for b in batch], device=self.device, dtype=torch.float,
+                [b["v_teacher"] for b in batch],
+                device=self.device,
+                dtype=torch.float,
             )
             vs_pred = self.vf(states)
             vf_loss = F.mse_loss(vs_pred, vs_teacher[..., None])
@@ -492,7 +494,9 @@ class TRPO(agent.AttributeSavingMixin, agent.BatchAgent):
         seqs_states = []
         for ep in dataset:
             states = self.batch_states(
-                [transition["state"] for transition in ep], self.device, self.phi,
+                [transition["state"] for transition in ep],
+                self.device,
+                self.phi,
             )
             if self.obs_normalizer:
                 states = self.obs_normalizer(states, update=False)
@@ -649,7 +653,9 @@ class TRPO(agent.AttributeSavingMixin, agent.BatchAgent):
             self.logger.info("Line search iteration: %s step size: %s", i, step_size)
             new_flat_params = flat_params + step_size * full_step
             new_params = _split_and_reshape_to_ndarrays(
-                new_flat_params, sizes=policy_params_sizes, shapes=policy_params_shapes,
+                new_flat_params,
+                sizes=policy_params_sizes,
+                shapes=policy_params_shapes,
             )
             _replace_params_data(policy_params, new_params)
             with torch.no_grad(), pfrl.utils.evaluating(self.policy):

--- a/pfrl/envs/abc.py
+++ b/pfrl/envs/abc.py
@@ -90,13 +90,19 @@ class ABC(env.Env):
         # (s_0, ..., s_N) + terminal state + offset
         self.n_dim_obs = self.size + 1 + self.n_max_offset
         self.observation_space = spaces.Box(
-            low=-np.inf, high=np.inf, shape=(self.n_dim_obs,), dtype=np.float32,
+            low=-np.inf,
+            high=np.inf,
+            shape=(self.n_dim_obs,),
+            dtype=np.float32,
         )
         if discrete:
             self.action_space = spaces.Discrete(self.size)
         else:
             self.action_space = spaces.Box(
-                low=-1.0, high=1.0, shape=(self.size,), dtype=np.float32,
+                low=-1.0,
+                high=1.0,
+                shape=(self.size,),
+                dtype=np.float32,
             )
 
     def observe(self):

--- a/pfrl/experiments/evaluator.py
+++ b/pfrl/experiments/evaluator.py
@@ -10,7 +10,12 @@ import pfrl
 
 
 def _run_episodes(
-    env, agent, n_steps, n_episodes, max_episode_len=None, logger=None,
+    env,
+    agent,
+    n_steps,
+    n_episodes,
+    max_episode_len=None,
+    logger=None,
 ):
     """Run multiple episodes and return returns."""
     assert (n_steps is None) != (n_episodes is None)
@@ -56,7 +61,12 @@ def _run_episodes(
 
 
 def run_evaluation_episodes(
-    env, agent, n_steps, n_episodes, max_episode_len=None, logger=None,
+    env,
+    agent,
+    n_steps,
+    n_episodes,
+    max_episode_len=None,
+    logger=None,
 ):
     """Run multiple evaluation episodes and return returns.
 
@@ -85,7 +95,12 @@ def run_evaluation_episodes(
 
 
 def _batch_run_episodes(
-    env, agent, n_steps, n_episodes, max_episode_len=None, logger=None,
+    env,
+    agent,
+    n_steps,
+    n_episodes,
+    max_episode_len=None,
+    logger=None,
 ):
     """Run multiple episodes and return returns in a batch manner."""
     assert (n_steps is None) != (n_episodes is None)
@@ -196,7 +211,12 @@ def _batch_run_episodes(
 
 
 def batch_run_evaluation_episodes(
-    env, agent, n_steps, n_episodes, max_episode_len=None, logger=None,
+    env,
+    agent,
+    n_steps,
+    n_episodes,
+    max_episode_len=None,
+    logger=None,
 ):
     """Run multiple evaluation episodes and return returns in a batch manner.
 
@@ -289,7 +309,10 @@ def create_tb_writer(outdir):
     tb_writer = SummaryWriter(log_dir=outdir)
     layout = {
         "Aggregate Charts": {
-            "mean w/ min-max": ["Margin", ["eval/mean", "eval/min", "eval/max"],],
+            "mean w/ min-max": [
+                "Margin",
+                ["eval/mean", "eval/min", "eval/max"],
+            ],
             "mean +/- std": [
                 "Margin",
                 ["eval/mean", "extras/meanplusstdev", "extras/meanminusstdev"],

--- a/pfrl/policies/gaussian_policy.py
+++ b/pfrl/policies/gaussian_policy.py
@@ -35,7 +35,10 @@ class GaussianHeadWithStateIndependentCovariance(nn.Module):
         var_size = {"spherical": 1, "diagonal": action_size}[var_type]
 
         self.var_param = nn.Parameter(
-            torch.tensor(np.broadcast_to(var_param_init, var_size), dtype=torch.float,)
+            torch.tensor(
+                np.broadcast_to(var_param_init, var_size),
+                dtype=torch.float,
+            )
         )
 
     def forward(self, mean):

--- a/pfrl/utils/recurrent.py
+++ b/pfrl/utils/recurrent.py
@@ -17,7 +17,15 @@ def is_recurrent(layer):
     # Import here to avoid circular import
     from pfrl.nn import Recurrent
 
-    return isinstance(layer, (nn.LSTM, nn.RNN, nn.GRU, Recurrent,))
+    return isinstance(
+        layer,
+        (
+            nn.LSTM,
+            nn.RNN,
+            nn.GRU,
+            Recurrent,
+        ),
+    )
 
 
 def mask_recurrent_state_at(recurrent_state, indices):

--- a/tests/agents_tests/basetest_ddpg.py
+++ b/tests/agents_tests/basetest_ddpg.py
@@ -31,7 +31,15 @@ class _TestDDPGOnABC(_TestTraining):
         )
 
     def make_ddpg_agent(
-        self, env, policy, q_func, actor_opt, critic_opt, explorer, rbuf, gpu,
+        self,
+        env,
+        policy,
+        q_func,
+        actor_opt,
+        critic_opt,
+        explorer,
+        rbuf,
+        gpu,
     ):
         raise NotImplementedError()
 

--- a/tests/agents_tests/basetest_training.py
+++ b/tests/agents_tests/basetest_training.py
@@ -62,7 +62,10 @@ class _TestTraining:
         # Test
         n_test_runs = 5
         eval_returns = run_evaluation_episodes(
-            test_env, agent, n_steps=None, n_episodes=n_test_runs,
+            test_env,
+            agent,
+            n_steps=None,
+            n_episodes=n_test_runs,
         )
         n_succeeded = np.sum(np.asarray(eval_returns) >= successful_return)
         if require_success:
@@ -139,7 +142,10 @@ class _TestBatchTrainingMixin(object):
         # Test
         n_test_runs = 5
         eval_returns = batch_run_evaluation_episodes(
-            test_env, agent, n_steps=None, n_episodes=n_test_runs,
+            test_env,
+            agent,
+            n_steps=None,
+            n_episodes=n_test_runs,
         )
         test_env.close()
         n_succeeded = np.sum(np.asarray(eval_returns) >= successful_return)

--- a/tests/agents_tests/test_a2c.py
+++ b/tests/agents_tests/test_a2c.py
@@ -77,7 +77,10 @@ class TestA2C:
         # Test
         n_test_runs = 100
         eval_returns = batch_run_evaluation_episodes(
-            test_env, agent, n_steps=None, n_episodes=n_test_runs,
+            test_env,
+            agent,
+            n_steps=None,
+            n_episodes=n_test_runs,
         )
         test_env.close()
         n_succeeded = np.sum(np.asarray(eval_returns) >= successful_return)
@@ -109,7 +112,9 @@ class TestA2C:
 
         obs_size = env.observation_space.low.size
         v = nn.Sequential(
-            nn.Linear(obs_size, hidden_size), nn.Tanh(), nn.Linear(hidden_size, 1),
+            nn.Linear(obs_size, hidden_size),
+            nn.Tanh(),
+            nn.Linear(hidden_size, 1),
         )
 
         if self.discrete:

--- a/tests/agents_tests/test_acer.py
+++ b/tests/agents_tests/test_acer.py
@@ -117,10 +117,12 @@ class TestDegenerateDistribution:
 @pytest.mark.parametrize("action_size", [1, 2])
 def test_bias_correction_gaussian(action_size):
     base_policy = nn.Sequential(
-        nn.Linear(1, action_size * 2), GaussianHeadWithDiagonalCovariance(),
+        nn.Linear(1, action_size * 2),
+        GaussianHeadWithDiagonalCovariance(),
     )
     another_policy = nn.Sequential(
-        nn.Linear(1, action_size * 2), GaussianHeadWithDiagonalCovariance(),
+        nn.Linear(1, action_size * 2),
+        GaussianHeadWithDiagonalCovariance(),
     )
     W = torch.rand(1, action_size)
     action_value = pfrl.action_value.SingleActionValue(
@@ -131,8 +133,14 @@ def test_bias_correction_gaussian(action_size):
 
 @pytest.mark.parametrize("n_actions", [2, 3])
 def test_bias_correction_softmax(n_actions):
-    base_policy = nn.Sequential(nn.Linear(1, n_actions), SoftmaxCategoricalHead(),)
-    another_policy = nn.Sequential(nn.Linear(1, n_actions), SoftmaxCategoricalHead(),)
+    base_policy = nn.Sequential(
+        nn.Linear(1, n_actions),
+        SoftmaxCategoricalHead(),
+    )
+    another_policy = nn.Sequential(
+        nn.Linear(1, n_actions),
+        SoftmaxCategoricalHead(),
+    )
     q_values = torch.rand(1, n_actions)
     action_value = pfrl.action_value.DiscreteActionValue(q_values)
     _test_bias_correction(base_policy, another_policy, action_value)
@@ -249,14 +257,18 @@ def _test_bias_correction(base_policy, another_policy, action_value):
 def test_compute_loss_with_kl_constraint_gaussian():
     action_size = 3
     policy = nn.Sequential(
-        nn.Linear(1, action_size * 2), GaussianHeadWithDiagonalCovariance(),
+        nn.Linear(1, action_size * 2),
+        GaussianHeadWithDiagonalCovariance(),
     )
     _test_compute_loss_with_kl_constraint(policy)
 
 
 def test_compute_loss_with_kl_constraint_softmax():
     n_actions = 3
-    policy = nn.Sequential(nn.Linear(1, n_actions), SoftmaxCategoricalHead(),)
+    policy = nn.Sequential(
+        nn.Linear(1, n_actions),
+        SoftmaxCategoricalHead(),
+    )
     _test_compute_loss_with_kl_constraint(policy)
 
 
@@ -363,10 +375,12 @@ class _TestACER:
             n_actions = action_space.n
             head = acer.ACERDiscreteActionHead(
                 pi=nn.Sequential(
-                    nn.Linear(hidden_size, n_actions), SoftmaxCategoricalHead(),
+                    nn.Linear(hidden_size, n_actions),
+                    SoftmaxCategoricalHead(),
                 ),
                 q=nn.Sequential(
-                    nn.Linear(hidden_size, n_actions), DiscreteActionValueHead(),
+                    nn.Linear(hidden_size, n_actions),
+                    DiscreteActionValueHead(),
                 ),
             )
         else:
@@ -376,9 +390,12 @@ class _TestACER:
                     nn.Linear(hidden_size, action_size * 2),
                     GaussianHeadWithDiagonalCovariance(),
                 ),
-                v=nn.Sequential(nn.Linear(hidden_size, 1),),
+                v=nn.Sequential(
+                    nn.Linear(hidden_size, 1),
+                ),
                 adv=nn.Sequential(
-                    ConcatObsAndAction(), nn.Linear(hidden_size + action_size, 1),
+                    ConcatObsAndAction(),
+                    nn.Linear(hidden_size + action_size, 1),
                 ),
             )
         if use_lstm:
@@ -390,7 +407,9 @@ class _TestACER:
             )
         else:
             model = nn.Sequential(
-                nn.Linear(obs_size, hidden_size), nn.LeakyReLU(), head,
+                nn.Linear(obs_size, hidden_size),
+                nn.LeakyReLU(),
+                head,
             )
         eps = 1e-8
         opt = pfrl.optimizers.SharedRMSpropEpsInsideSqrt(

--- a/tests/agents_tests/test_categorical_dqn.py
+++ b/tests/agents_tests/test_categorical_dqn.py
@@ -45,13 +45,16 @@ def _apply_categorical_projection_naive(y, y_probs, z):
 
 
 @pytest.mark.parametrize(
-    "batch_size", [1, 7],
+    "batch_size",
+    [1, 7],
 )
 @pytest.mark.parametrize(
-    "n_atoms", [2, 5],
+    "n_atoms",
+    [2, 5],
 )
 @pytest.mark.parametrize(
-    "v_range", [(-3, -1), (-2, 0), (-2, 1), (0, 1), (1, 5)],
+    "v_range",
+    [(-3, -1), (-2, 0), (-2, 1), (0, 1), (1, 5)],
 )
 class TestApplyCategoricalProjectionToRandomCases:
     @pytest.fixture(autouse=True)
@@ -164,12 +167,26 @@ class TestApplyCategoricalProjectionToManualCases(unittest.TestCase):
         n_atoms = 4
         # delta_z=2/3=0.66666... is not exact
         z = np.linspace(v_min, v_max, num=n_atoms, dtype=np.float32)
-        y = np.asarray([[-1, -1, 1, 1], [-1, 0, 1, 1],], dtype=np.float32)
+        y = np.asarray(
+            [
+                [-1, -1, 1, 1],
+                [-1, 0, 1, 1],
+            ],
+            dtype=np.float32,
+        )
         y_probs = np.asarray(
-            [[0.5, 0.1, 0.1, 0.3], [0.5, 0.2, 0.0, 0.3],], dtype=np.float32
+            [
+                [0.5, 0.1, 0.1, 0.3],
+                [0.5, 0.2, 0.0, 0.3],
+            ],
+            dtype=np.float32,
         )
         proj_gt = np.asarray(
-            [[0.6, 0.0, 0.0, 0.4], [0.5, 0.1, 0.1, 0.3],], dtype=np.float32
+            [
+                [0.6, 0.0, 0.0, 0.4],
+                [0.5, 0.1, 0.1, 0.3],
+            ],
+            dtype=np.float32,
         )
 
         proj = (

--- a/tests/agents_tests/test_ddpg.py
+++ b/tests/agents_tests/test_ddpg.py
@@ -9,7 +9,15 @@ from pfrl.agents.ddpg import DDPG
 # Batch training with recurrent models is currently not supported
 class TestDDPGOnContinuousPOABC(base._TestDDPGOnContinuousPOABC):
     def make_ddpg_agent(
-        self, env, policy, q_func, actor_opt, critic_opt, explorer, rbuf, gpu,
+        self,
+        env,
+        policy,
+        q_func,
+        actor_opt,
+        critic_opt,
+        explorer,
+        rbuf,
+        gpu,
     ):
         return DDPG(
             policy,
@@ -30,7 +38,15 @@ class TestDDPGOnContinuousPOABC(base._TestDDPGOnContinuousPOABC):
 
 class TestDDPGOnContinuousABC(_TestBatchTrainingMixin, base._TestDDPGOnContinuousABC):
     def make_ddpg_agent(
-        self, env, policy, q_func, actor_opt, critic_opt, explorer, rbuf, gpu,
+        self,
+        env,
+        policy,
+        q_func,
+        actor_opt,
+        critic_opt,
+        explorer,
+        rbuf,
+        gpu,
     ):
         return DDPG(
             policy,

--- a/tests/agents_tests/test_iqn.py
+++ b/tests/agents_tests/test_iqn.py
@@ -29,9 +29,13 @@ class TestIQNOnDiscreteABC(
         obs_size = env.observation_space.low.size
         hidden_size = 64
         return iqn.ImplicitQuantileQFunction(
-            psi=nn.Sequential(nn.Linear(obs_size, hidden_size), nn.ReLU(),),
+            psi=nn.Sequential(
+                nn.Linear(obs_size, hidden_size),
+                nn.ReLU(),
+            ),
             phi=nn.Sequential(
-                pfrl.agents.iqn.CosineBasisLinear(32, hidden_size), nn.ReLU(),
+                pfrl.agents.iqn.CosineBasisLinear(32, hidden_size),
+                nn.ReLU(),
             ),
             f=nn.Linear(hidden_size, env.action_space.n),
         )
@@ -64,10 +68,15 @@ class TestIQNOnDiscretePOABC(
             psi=pfrl.nn.RecurrentSequential(
                 nn.Linear(obs_size, hidden_size),
                 nn.ReLU(),
-                nn.RNN(num_layers=1, input_size=hidden_size, hidden_size=hidden_size,),
+                nn.RNN(
+                    num_layers=1,
+                    input_size=hidden_size,
+                    hidden_size=hidden_size,
+                ),
             ),
             phi=nn.Sequential(
-                pfrl.agents.iqn.CosineBasisLinear(32, hidden_size), nn.ReLU(),
+                pfrl.agents.iqn.CosineBasisLinear(32, hidden_size),
+                nn.ReLU(),
             ),
             f=nn.Linear(hidden_size, env.action_space.n),
         )
@@ -101,7 +110,8 @@ def test_compute_eltwise_huber_quantile_loss(batch_size, N, N_prime):
 
     loss = iqn.compute_eltwise_huber_quantile_loss(y, t, tau)
     y_b, t_b = torch.broadcast_tensors(
-        y.reshape(batch_size, N, 1), t.reshape(batch_size, 1, N_prime),
+        y.reshape(batch_size, N, 1),
+        t.reshape(batch_size, 1, N_prime),
     )
     assert loss.shape == (batch_size, N, N_prime)
     huber_loss = nn.functional.smooth_l1_loss(y_b, t_b, reduction="none")
@@ -128,10 +138,14 @@ def test_compute_eltwise_huber_quantile_loss(batch_size, N, N_prime):
                     [correct_scalar_loss], [y], retain_graph=True
                 )[0][i, j]
                 torch_assert_allclose(
-                    scalar_loss, correct_scalar_loss, atol=1e-5,
+                    scalar_loss,
+                    correct_scalar_loss,
+                    atol=1e-5,
                 )
                 torch_assert_allclose(
-                    scalar_grad, correct_scalar_grad, atol=1e-5,
+                    scalar_grad,
+                    correct_scalar_grad,
+                    atol=1e-5,
                 )
 
 
@@ -147,5 +161,7 @@ def test_cosine_basis_functions(batch_size, m, n_basis_functions):
         for j in range(m):
             for k in range(n_basis_functions):
                 torch_assert_allclose(
-                    y[i, j, k], torch.cos(x[i, j] * (k + 1) * np.pi), atol=1e-5,
+                    y[i, j, k],
+                    torch.cos(x[i, j] * (k + 1) * np.pi),
+                    atol=1e-5,
                 )

--- a/tests/agents_tests/test_ppo.py
+++ b/tests/agents_tests/test_ppo.py
@@ -71,19 +71,35 @@ class TestYieldSubsetOfSequencesWithFixedNumberOfItems(unittest.TestCase):
             list(
                 ppo._yield_subset_of_sequences_with_fixed_number_of_items(episodes, 4)
             ),
-            [[[1, 2, 3], [4]], [[5], [6, 7, 8]], [[9], [10, 11, 12]],],
+            [
+                [[1, 2, 3], [4]],
+                [[5], [6, 7, 8]],
+                [[9], [10, 11, 12]],
+            ],
         )
         self.assertEqual(
             list(
                 ppo._yield_subset_of_sequences_with_fixed_number_of_items(episodes, 3)
             ),
-            [[[1, 2, 3]], [[4, 5], [6]], [[7, 8], [9]], [[10, 11, 12]],],
+            [
+                [[1, 2, 3]],
+                [[4, 5], [6]],
+                [[7, 8], [9]],
+                [[10, 11, 12]],
+            ],
         )
         self.assertEqual(
             list(
                 ppo._yield_subset_of_sequences_with_fixed_number_of_items(episodes, 2)
             ),
-            [[[1, 2]], [[3], [4]], [[5], [6]], [[7, 8]], [[9], [10]], [[11, 12]],],
+            [
+                [[1, 2]],
+                [[3], [4]],
+                [[5], [6]],
+                [[7, 8]],
+                [[9], [10]],
+                [[11, 12]],
+            ],
         )
 
 
@@ -101,13 +117,22 @@ class TestLimitSequenceLength(unittest.TestCase):
         )
         self.assertEqual(
             ppo._limit_sequence_length(episodes, 2),
-            [[1, 2], [3], [4, 5], [6, 7], [8], [9],],
+            [
+                [1, 2],
+                [3],
+                [4, 5],
+                [6, 7],
+                [8],
+                [9],
+            ],
         )
         self.assertEqual(
-            ppo._limit_sequence_length(episodes, 3), episodes,
+            ppo._limit_sequence_length(episodes, 3),
+            episodes,
         )
         self.assertEqual(
-            ppo._limit_sequence_length(episodes, 4), episodes,
+            ppo._limit_sequence_length(episodes, 4),
+            episodes,
         )
 
     def test_random(self):
@@ -151,10 +176,15 @@ def test_ppo_dataset_recurrent_and_non_recurrent_equivalence(
     n_actions = 3
 
     non_recurrent_model = pfrl.nn.Branched(
-        nn.Sequential(nn.Linear(obs_size, n_actions), SoftmaxCategoricalHead(),),
+        nn.Sequential(
+            nn.Linear(obs_size, n_actions),
+            SoftmaxCategoricalHead(),
+        ),
         nn.Linear(obs_size, 1),
     )
-    recurrent_model = RecurrentSequential(non_recurrent_model,)
+    recurrent_model = RecurrentSequential(
+        non_recurrent_model,
+    )
 
     dataset = pfrl.agents.ppo._make_dataset(
         episodes=copy.deepcopy(episodes),
@@ -482,7 +512,12 @@ class _TestPPO:
 class TestPPONonRecurrent(_TestPPO):
     @pytest.fixture(autouse=True)
     def set_params(
-        self, clip_eps_vf, lambd, discrete, standardize_advantages, episodic,
+        self,
+        clip_eps_vf,
+        lambd,
+        discrete,
+        standardize_advantages,
+        episodic,
     ):
         self.clip_eps_vf = clip_eps_vf
         self.lambd = lambd
@@ -500,7 +535,12 @@ class TestPPONonRecurrent(_TestPPO):
 class TestPPORecurrent(_TestPPO):
     @pytest.fixture(autouse=True)
     def set_params(
-        self, clip_eps_vf, lambd, discrete, standardize_advantages, episodic,
+        self,
+        clip_eps_vf,
+        lambd,
+        discrete,
+        standardize_advantages,
+        episodic,
     ):
         self.clip_eps_vf = clip_eps_vf
         self.lambd = lambd

--- a/tests/agents_tests/test_reinforce.py
+++ b/tests/agents_tests/test_reinforce.py
@@ -82,7 +82,11 @@ class TestREINFORCE:
             )
         if use_lstm:
             model = pfrl.nn.RecurrentSequential(
-                nn.LSTM(num_layers=1, input_size=obs_size, hidden_size=hidden_size,),
+                nn.LSTM(
+                    num_layers=1,
+                    input_size=obs_size,
+                    hidden_size=hidden_size,
+                ),
                 nn.Linear(hidden_size, hidden_size),
                 nn.LeakyReLU(),
                 nn.Linear(hidden_size, output_size),
@@ -125,7 +129,10 @@ class TestREINFORCE:
         env = make_env(0, True)
         n_test_runs = 5
         eval_returns = run_evaluation_episodes(
-            env, agent, n_steps=None, n_episodes=n_test_runs,
+            env,
+            agent,
+            n_steps=None,
+            n_episodes=n_test_runs,
         )
         if require_success:
             successful_return = 1

--- a/tests/agents_tests/test_soft_actor_critic.py
+++ b/tests/agents_tests/test_soft_actor_critic.py
@@ -176,7 +176,10 @@ class TestSoftActorCritic:
         policy = nn.Sequential(
             nn.Linear(obs_size, hidden_size),
             nn.ReLU(),
-            nn.Linear(hidden_size, action_size * 2,),
+            nn.Linear(
+                hidden_size,
+                action_size * 2,
+            ),
             nn.Tanh(),
             Lambda(squashed_diagonal_gaussian_head),
         )
@@ -223,7 +226,11 @@ class TestSoftActorCritic:
         return agent
 
     def make_env_and_successful_return(self, test):
-        env = ABC(discrete=False, episodic=self.episodic or test, deterministic=test,)
+        env = ABC(
+            discrete=False,
+            episodic=self.episodic or test,
+            deterministic=test,
+        )
         return env, 1
 
     def make_vec_env_and_successful_return(self, test, num_envs=3):

--- a/tests/agents_tests/test_td3.py
+++ b/tests/agents_tests/test_td3.py
@@ -210,7 +210,11 @@ class TestTD3:
         return agent
 
     def make_env_and_successful_return(self, test):
-        env = ABC(discrete=False, episodic=self.episodic or test, deterministic=test,)
+        env = ABC(
+            discrete=False,
+            episodic=self.episodic or test,
+            deterministic=test,
+        )
         return env, 1
 
     def make_vec_env_and_successful_return(self, test, num_envs=3):

--- a/tests/collections_tests/test_prioritized.py
+++ b/tests/collections_tests/test_prioritized.py
@@ -59,7 +59,8 @@ def test_prioritized_buffer_flood(
     capacity, wait_priority_after_sampling, initial_priority, uniform_ratio
 ):
     buf = prioritized.PrioritizedBuffer(
-        capacity=capacity, wait_priority_after_sampling=wait_priority_after_sampling,
+        capacity=capacity,
+        wait_priority_after_sampling=wait_priority_after_sampling,
     )
     for _ in range(100):
         for x in range(capacity + 1):

--- a/tests/experiments_tests/test_train_agent_async.py
+++ b/tests/experiments_tests/test_train_agent_async.py
@@ -35,7 +35,9 @@ def test_train_agent_async(num_envs, max_episode_len):
             ] * 1000
         else:
             # Continuing env
-            env.step.side_effect = [(("state", 1), 0, False, {}),] * 1000
+            env.step.side_effect = [
+                (("state", 1), 0, False, {}),
+            ] * 1000
         return env
 
     # Keep references to mock envs to check their states later

--- a/tests/experiments_tests/test_train_agent_batch.py
+++ b/tests/experiments_tests/test_train_agent_batch.py
@@ -33,7 +33,9 @@ def test_train_agent_batch(num_envs, max_episode_len, steps, enable_evaluation):
             ] * 1000
         else:
             # Continuing env
-            env.step.side_effect = [(("state", 1), 0, False, {}),] * 1000
+            env.step.side_effect = [
+                (("state", 1), 0, False, {}),
+            ] * 1000
         return env
 
     vec_env = pfrl.envs.SerialVectorEnv([make_env() for _ in range(num_envs)])
@@ -195,7 +197,10 @@ class TestTrainAgentBatchNeedsReset(unittest.TestCase):
         vec_env = pfrl.envs.SerialVectorEnv([make_env(i) for i in range(2)])
 
         eval_stats_history = pfrl.experiments.train_agent_batch(
-            agent=agent, env=vec_env, steps=steps, outdir=outdir,
+            agent=agent,
+            env=vec_env,
+            steps=steps,
+            outdir=outdir,
         )
 
         # No evaluation invoked when evaluator=None (default) is passed to

--- a/tests/nn_tests/test_branched.py
+++ b/tests/nn_tests/test_branched.py
@@ -10,7 +10,10 @@ from pfrl.testing import torch_assert_allclose
 def test_branched(batch_size):
     link1 = nn.Linear(2, 3)
     link2 = nn.Linear(2, 5)
-    link3 = nn.Sequential(nn.Linear(2, 7), nn.Tanh(),)
+    link3 = nn.Sequential(
+        nn.Linear(2, 7),
+        nn.Tanh(),
+    )
     plink = Branched(link1, link2, link3)
     x = torch.zeros(batch_size, 2, dtype=torch.float)
     pout = plink(x)

--- a/tests/nn_tests/test_lmbda.py
+++ b/tests/nn_tests/test_lmbda.py
@@ -6,7 +6,11 @@ from pfrl.testing import torch_assert_allclose
 
 
 def test_lambda():
-    model = nn.Sequential(nn.ReLU(), Lambda(lambda x: x + 1), nn.ReLU(),)
+    model = nn.Sequential(
+        nn.ReLU(),
+        Lambda(lambda x: x + 1),
+        nn.ReLU(),
+    )
     x = torch.rand(3, 2)
     # Since x is all positive, ReLU will not have any effects
     y = model(x)

--- a/tests/nn_tests/test_recurrent_branched.py
+++ b/tests/nn_tests/test_recurrent_branched.py
@@ -26,7 +26,9 @@ class TestRecurrentBranched(unittest.TestCase):
             RecurrentSequential(
                 nn.RNN(num_layers=1, input_size=in_size, hidden_size=out1_size),
             ),
-            RecurrentSequential(nn.Linear(in_size, out2_size),),
+            RecurrentSequential(
+                nn.Linear(in_size, out2_size),
+            ),
         )
 
         if gpu >= 0:

--- a/tests/test_action_value.py
+++ b/tests/test_action_value.py
@@ -172,7 +172,10 @@ class TestQuantileDiscreteActionValue(unittest.TestCase):
         self.action_size = 3
         self.n_taus = 5
         self.quantiles = torch.randn(
-            self.batch_size, self.n_taus, self.action_size, dtype=torch.float,
+            self.batch_size,
+            self.n_taus,
+            self.action_size,
+            dtype=torch.float,
         )
         self.av = action_value.QuantileDiscreteActionValue(self.quantiles)
         self.q_values = self.quantiles.mean(axis=1)

--- a/tests/utils_tests/test_batch_states.py
+++ b/tests/utils_tests/test_batch_states.py
@@ -28,10 +28,24 @@ class TestBatchStates(unittest.TestCase):
         self.assertIsInstance(batch, tuple)
         batch_a, batch_b, batch_c = batch
         np.testing.assert_allclose(
-            batch_a, np.asarray([[[0, 2], [4, 6]], [[2, 4], [6, 8]],])
+            batch_a,
+            np.asarray(
+                [
+                    [[0, 2], [4, 6]],
+                    [[2, 4], [6, 8]],
+                ]
+            ),
         )
         np.testing.assert_allclose(batch_b, np.asarray([0, 1]))
-        np.testing.assert_allclose(batch_c, np.asarray([[0], [3],]))
+        np.testing.assert_allclose(
+            batch_c,
+            np.asarray(
+                [
+                    [0],
+                    [3],
+                ]
+            ),
+        )
 
     def test_cpu(self):
         self._test(gpu=-1)

--- a/tests/utils_tests/test_clip_l2_grad_norm.py
+++ b/tests/utils_tests/test_clip_l2_grad_norm.py
@@ -20,7 +20,11 @@ def _test_clip_l2_grad_norm_(gpu):
         device = torch.device("cuda:{}".format(gpu))
     else:
         device = torch.device("cpu")
-    model = nn.Sequential(nn.Linear(2, 10), nn.ReLU(), nn.Linear(10, 3),).to(device)
+    model = nn.Sequential(
+        nn.Linear(2, 10),
+        nn.ReLU(),
+        nn.Linear(10, 3),
+    ).to(device)
     x = torch.rand(7, 2).to(device)
 
     def backward():

--- a/tests/utils_tests/test_pretrained_models.py
+++ b/tests/utils_tests/test_pretrained_models.py
@@ -96,9 +96,14 @@ class TestLoadIQN:
                 nn.ReLU(),
                 nn.Flatten(),
             ),
-            phi=nn.Sequential(pfrl.agents.iqn.CosineBasisLinear(64, 3136), nn.ReLU(),),
+            phi=nn.Sequential(
+                pfrl.agents.iqn.CosineBasisLinear(64, 3136),
+                nn.ReLU(),
+            ),
             f=nn.Sequential(
-                nn.Linear(3136, 512), nn.ReLU(), nn.Linear(512, n_actions),
+                nn.Linear(3136, 512),
+                nn.ReLU(),
+                nn.Linear(512, n_actions),
             ),
         )
 
@@ -210,7 +215,10 @@ class TestLoadA3C:
             nn.Linear(2592, 256),
             nn.ReLU(),
             pfrl.nn.Branched(
-                nn.Sequential(nn.Linear(256, n_actions), SoftmaxCategoricalHead(),),
+                nn.Sequential(
+                    nn.Linear(256, n_actions),
+                    SoftmaxCategoricalHead(),
+                ),
                 nn.Linear(256, 1),
             ),
         )

--- a/tests/wrappers_tests/test_atari_wrappers.py
+++ b/tests/wrappers_tests/test_atari_wrappers.py
@@ -38,7 +38,12 @@ def test_frame_stack(dtype, k):
             assert False
         env.reset.side_effect = [dtyped_rand() for _ in range(steps)]
         env.step.side_effect = [
-            (dtyped_rand(), np_random.rand(), bool(np_random.randint(2)), {},)
+            (
+                dtyped_rand(),
+                np_random.rand(),
+                bool(np_random.randint(2)),
+                {},
+            )
             for _ in range(steps)
         ]
         env.action_space = gym.spaces.Discrete(2)
@@ -105,7 +110,12 @@ def test_scaled_float_frame(dtype):
             assert False
         env.reset.side_effect = [dtyped_rand() for _ in range(steps)]
         env.step.side_effect = [
-            (dtyped_rand(), np_random.rand(), bool(np_random.randint(2)), {},)
+            (
+                dtyped_rand(),
+                np_random.rand(),
+                bool(np_random.randint(2)),
+                {},
+            )
             for _ in range(steps)
         ]
         env.action_space = gym.spaces.Discrete(2)

--- a/tests/wrappers_tests/test_render.py
+++ b/tests/wrappers_tests/test_render.py
@@ -6,7 +6,12 @@ import pfrl
 
 
 @pytest.mark.parametrize(
-    "render_kwargs", [{}, {"mode": "human"}, {"mode": "rgb_array"},]
+    "render_kwargs",
+    [
+        {},
+        {"mode": "human"},
+        {"mode": "rgb_array"},
+    ],
 )
 def test_render(render_kwargs):
     orig_env = mock.Mock()


### PR DESCRIPTION
We have been using the specific commit of `black` on github to use its latest features. But now the one on pypi is newer. This PR simply switches to the latest `black` on pypi.

The suggested changes seem to be caused by this: https://github.com/psf/black/pull/1612. I think these are good changes.