### PR TITLE
call evaluation_hooks in Evaluator

### DIFF
--- a/pfrl/experiments/evaluation_hooks.py
+++ b/pfrl/experiments/evaluation_hooks.py
@@ -12,26 +12,39 @@ except ImportError:
 class EvaluationHook(object, metaclass=ABCMeta):
     """Hook function that will be called after evaluation.
 
-    This class is for clarifying the interface required for EvaluationHook functions.
-    You don't need to inherit this class to define your own hooks. Any callable that
-    accepts (env, agent, evaluator, step, eval_score) as arguments can be used as an
-    evaluation hook.
+    Every evaluation hook function must inherit this class.
 
-    Note that:
-    - ``step`` is the current training step, not the number of evaluations so far.
-    - ``train_agent_async`` DOES NOT support EvaluationHook.
+    Attributes:
+        support_train_agent (bool):
+            Set to ``True`` if the hook can be used in
+            pfrl.experiments.train_agent.train_agent_with_evaluation.
+        support_train_agent_batch (bool):
+            Set to ``True`` if the hook can be used in
+            pfrl.experiments.train_agent_batch.train_agent_batch_with_evaluation.
+        support_train_agent_async (bool):
+            Set to ``True`` if the hook can be used in
+            pfrl.experiments.train_agent_async.train_agent_async.
     """
 
+    support_train_agent = False
+    support_train_agent_batch = False
+    support_train_agent_async = False
+
     @abstractmethod
-    def __call__(self, env, agent, evaluator, step, eval_score):
+    def __call__(self, env, agent, evaluator, step, eval_stats, agent_stats, env_stats):
         """Call the hook.
 
         Args:
             env: Environment.
             agent: Agent.
             evaluator: Evaluator.
-            step: Current timestep.
-            eval_score: Evaluation score at t=`step`.
+            step: Current timestep. (Not the number of evaluations so far)
+            eval_stats (dict): Last evaluation stats from
+                pfrl.experiments.evaluator.eval_performance().
+            agent_stats (List of pairs): Last agent stats from
+                agent.get_statistics().
+            env_stats: Last environment stats from
+                env.get_statistics().
         """
         raise NotImplementedError
 
@@ -42,26 +55,45 @@ class OptunaPrunerHook(EvaluationHook):
     Optuna regards trials which raise `optuna.TrialPruned` as unpromissed and
     prune them at the early stages of the training.
 
-    Note that:
-    - ``step`` is the current training step, not the number of evaluations so far.
-    - ``train_agent_async`` DOES NOT support EvaluationHook.
-      - This hook stops trial by raising an exception, but re-raise error among process
-        is not straight forward.
+    Note that this hook does not support
+    pfrl.experiments.train_agent_async.train_agent_async.
+    Optuna detects pruning signal by `optuna.TrialPruned` exception, but async training
+    mode doesn't re-raise subprocess' exceptions. (See: pfrl.utils.async_.py)
 
     Args:
         trial (optuna.Trial): Current trial.
-    Raises:
-        optuna.TrialPruned: Raise when the trial should be pruned immediately.
-            Note that you don't need to care about this exception since Optuna will
-            catch `optuna.TrialPruned` and stop the trial properly.
     """
+
+    support_train_agent = True
+    support_train_agent_batch = True
+    support_train_agent_async = False  # unsupported
 
     def __init__(self, trial):
         if not _optuna_available:
             raise RuntimeError("OptunaPrunerHook requires optuna installed.")
         self.trial = trial
 
-    def __call__(self, env, agent, evaluator, step, eval_score):
-        self.trial.report(eval_score, step)
+    def __call__(self, env, agent, evaluator, step, eval_stats, agent_stats, env_stats):
+        """Call the hook.
+
+        Args:
+            env: Environment.
+            agent: Agent.
+            evaluator: Evaluator.
+            step: Current timestep. (Not the number of evaluations so far)
+            eval_stats (dict): Last evaluation stats from
+                pfrl.experiments.evaluator.eval_performance().
+            agent_stats (List of pairs): Last agent stats from
+                agent.get_statistics().
+            env_stats: Last environment stats from
+                env.get_statistics().
+
+        Raises:
+            optuna.TrialPruned: Raise when the trial should be pruned immediately.
+                Note that you don't need to care about this exception since Optuna will
+                catch `optuna.TrialPruned` and stop the trial properly.
+        """
+        score = eval_stats["mean"]
+        self.trial.report(score, step)
         if self.trial.should_prune():
             raise optuna.TrialPruned()

--- a/pfrl/experiments/evaluator.py
+++ b/pfrl/experiments/evaluator.py
@@ -493,7 +493,7 @@ class Evaluator(object):
                 step=t,
                 eval_stats=eval_stats,
                 agent_stats=agent_stats,
-                env_stats=env_stats
+                env_stats=env_stats,
             )
 
         if mean > self.max_score:
@@ -624,7 +624,7 @@ class AsyncEvaluator(object):
                 step=t,
                 eval_stats=eval_stats,
                 agent_stats=agent_stats,
-                env_stats=env_stats
+                env_stats=env_stats,
             )
 
         with self._max_score.get_lock():

--- a/pfrl/experiments/train_agent.py
+++ b/pfrl/experiments/train_agent.py
@@ -32,7 +32,6 @@ def train_agent(
     evaluator=None,
     successful_score=None,
     step_hooks=(),
-    evaluation_hooks=(),
     logger=None,
 ):
 
@@ -84,8 +83,6 @@ def train_agent(
                         eval_stats = dict(stats)
                         eval_stats["eval_score"] = eval_score
                         eval_stats_history.append(eval_stats)
-                        for hook in evaluation_hooks:
-                            hook(env, agent, evaluator, t, eval_score)
                     if (
                         successful_score is not None
                         and evaluator.max_score >= successful_score
@@ -153,9 +150,9 @@ def train_agent_with_evaluation(
         step_hooks (Sequence): Sequence of callable objects that accepts
             (env, agent, step) as arguments. They are called every step.
             See pfrl.experiments.hooks.
-        evaluation_hooks (Sequence): Sequence of callable objects that accepts
-            (env, agent, evaluator, step, eval_score) as arguments. They are
-            called every evaluation. See pfrl.experiments.evaluation_hooks.
+        evaluation_hooks (Sequence): Sequence of
+            pfrl.experiments.evaluation_hooks.EvaluationHook objects. They are
+            called after each evaluation.
         save_best_so_far_agent (bool): If set to True, after each evaluation
             phase, if the score (= mean return of evaluation episodes) exceeds
             the best-so-far score, the current agent is saved.
@@ -167,6 +164,12 @@ def train_agent_with_evaluation(
     """
 
     logger = logger or logging.getLogger(__name__)
+
+    for hook in evaluation_hooks:
+        if not hook.support_train_agent:
+            raise ValueError(
+                "{} does not support train_agent_with_evaluation().".format(hook)
+            )
 
     os.makedirs(outdir, exist_ok=True)
 
@@ -185,6 +188,7 @@ def train_agent_with_evaluation(
         max_episode_len=eval_max_episode_len,
         env=eval_env,
         step_offset=step_offset,
+        evaluation_hooks=evaluation_hooks,
         save_best_so_far_agent=save_best_so_far_agent,
         use_tensorboard=use_tensorboard,
         logger=logger,
@@ -201,7 +205,6 @@ def train_agent_with_evaluation(
         evaluator=evaluator,
         successful_score=successful_score,
         step_hooks=step_hooks,
-        evaluation_hooks=evaluation_hooks,
         logger=logger,
     )
 

--- a/pfrl/experiments/train_agent_async.py
+++ b/pfrl/experiments/train_agent_async.py
@@ -219,9 +219,7 @@ def train_agent_async(
 
     for hook in evaluation_hooks:
         if not hook.support_train_agent_async:
-            raise ValueError(
-                "{} does not support train_agent_async().".format(hook)
-            )
+            raise ValueError("{} does not support train_agent_async().".format(hook))
 
     # Prevent numpy from using multiple threads
     os.environ["OMP_NUM_THREADS"] = "1"

--- a/pfrl/experiments/train_agent_async.py
+++ b/pfrl/experiments/train_agent_async.py
@@ -162,6 +162,7 @@ def train_agent_async(
     agent=None,
     make_agent=None,
     global_step_hooks=[],
+    evaluation_hooks=(),
     save_best_so_far_agent=True,
     use_tensorboard=False,
     logger=None,
@@ -193,6 +194,9 @@ def train_agent_async(
         global_step_hooks (list): List of callable objects that accepts
             (env, agent, step) as arguments. They are called every global
             step. See pfrl.experiments.hooks.
+        evaluation_hooks (Sequence): Sequence of
+            pfrl.experiments.evaluation_hooks.EvaluationHook objects. They are
+            called after each evaluation.
         save_best_so_far_agent (bool): If set to True, after each evaluation,
             if the score (= mean return of evaluation episodes) exceeds
             the best-so-far score, the current agent is saved.
@@ -212,6 +216,12 @@ def train_agent_async(
     """
 
     logger = logger or logging.getLogger(__name__)
+
+    for hook in evaluation_hooks:
+        if not hook.support_train_agent:
+            raise ValueError(
+                "{} does not support train_agent_async().".format(hook)
+            )
 
     # Prevent numpy from using multiple threads
     os.environ["OMP_NUM_THREADS"] = "1"

--- a/pfrl/experiments/train_agent_async.py
+++ b/pfrl/experiments/train_agent_async.py
@@ -218,7 +218,7 @@ def train_agent_async(
     logger = logger or logging.getLogger(__name__)
 
     for hook in evaluation_hooks:
-        if not hook.support_train_agent:
+        if not hook.support_train_agent_async:
             raise ValueError(
                 "{} does not support train_agent_async().".format(hook)
             )

--- a/pfrl/experiments/train_agent_async.py
+++ b/pfrl/experiments/train_agent_async.py
@@ -262,6 +262,7 @@ def train_agent_async(
             outdir=outdir,
             max_episode_len=max_episode_len,
             step_offset=step_offset,
+            evaluation_hooks=evaluation_hooks,
             save_best_so_far_agent=save_best_so_far_agent,
             logger=logger,
         )

--- a/pfrl/experiments/train_agent_batch.py
+++ b/pfrl/experiments/train_agent_batch.py
@@ -216,7 +216,7 @@ def train_agent_batch_with_evaluation(
     logger = logger or logging.getLogger(__name__)
 
     for hook in evaluation_hooks:
-        if not hook.support_train_agent:
+        if not hook.support_train_agent_batch:
             raise ValueError(
                 "{} does not support train_agent_batch_with_evaluation().".format(hook)
             )

--- a/tests/experiments_tests/test_evaluation_hooks.py
+++ b/tests/experiments_tests/test_evaluation_hooks.py
@@ -16,11 +16,15 @@ class TestOptunaPrunerHook(unittest.TestCase):
         agent = Mock()
         evaluator = Mock()
         step = 42
-        eval_score = 3.14
+        eval_stats = {"mean": 3.14}
+        agent_stats = [("dummy", 2.7)]
+        env_stats = []
 
-        optuna_pruner_hook(env, agent, evaluator, step, eval_score)
+        optuna_pruner_hook(
+            env, agent, evaluator, step, eval_stats, agent_stats, env_stats
+        )
 
-        trial.report.assert_called_once_with(eval_score, step)
+        trial.report.assert_called_once_with(eval_stats["mean"], step)
 
     def test_should_prune(self):
         trial = Mock()
@@ -31,10 +35,13 @@ class TestOptunaPrunerHook(unittest.TestCase):
         agent = Mock()
         evaluator = Mock()
         step = 42
-        eval_score = 3.14
+        eval_stats = {"mean": 3.14}
+        agent_stats = [("dummy", 2.7)]
+        env_stats = []
 
         with self.assertRaises(optuna.TrialPruned):
-            optuna_pruner_hook(env, agent, evaluator, step, eval_score)
+            optuna_pruner_hook(
+                env, agent, evaluator, step, eval_stats, agent_stats, env_stats
+            )
 
-        trial.report.assert_called()
-        trial.report.assert_called_once_with(eval_score, step)
+        trial.report.assert_called_once_with(eval_stats["mean"], step)

--- a/tests/experiments_tests/test_train_agent.py
+++ b/tests/experiments_tests/test_train_agent.py
@@ -2,6 +2,8 @@ import tempfile
 import unittest
 from unittest import mock
 
+import pytest
+
 import pfrl
 
 
@@ -91,79 +93,42 @@ class TestTrainAgent(unittest.TestCase):
             # step starts with 1
             self.assertEqual(args[2], i + 1)
 
-    def test_with_evaluation_hooks(self):
+    def test_unsupported_evaluation_hook(self):
+        class UnsupportedEvaluationHook(
+            pfrl.experiments.evaluation_hooks.EvaluationHook
+        ):
+            support_train_agent = False
+            support_train_agent_batch = True
+            support_train_agent_async = True
 
-        outdir = tempfile.mkdtemp()
+            def __call__(
+                self,
+                env,
+                agent,
+                evaluator,
+                step,
+                eval_stats,
+                agent_stats,
+                env_stats,
+            ):
+                pass
 
-        agent = mock.Mock()
-        env = mock.Mock()
-        # Reaches the terminal state after five actions
-        env.reset.side_effect = [("state", 0)]
-        env.step.side_effect = [
-            (("state", 1), 0, False, {}),
-            (("state", 2), 0, False, {}),
-            (("state", 3), -0.5, False, {}),
-            (("state", 4), 0, False, {}),
-            (("state", 5), 1, True, {}),
-        ]
-        hook = mock.Mock()
+        unsupported_evaluation_hook = UnsupportedEvaluationHook()
 
-        n_resets = 1
-        dummy_stats = [
-            ("average_q", 3.14),
-            ("average_loss", 2.7),
-            ("cumulative_steps", 42),
-            ("n_updates", 8),
-            ("rlen", 1),
-        ]
-        agent.get_statistics.side_effect = [dummy_stats] * n_resets
+        with pytest.raises(ValueError) as exception:
+            pfrl.experiments.train_agent_with_evaluation(
+                agent=mock.Mock(),
+                env=mock.Mock(),
+                steps=1,
+                eval_n_steps=1,
+                eval_n_episodes=None,
+                eval_interval=1,
+                outdir=mock.Mock(),
+                evaluation_hooks=[unsupported_evaluation_hook],
+            )
 
-        evaluator = mock.Mock()
-        # evaluator.evaluate_if_necessary is invoked after episode ends
-        # (when evaluator is not None for train_agent)
-        dummy_eval_score = 42
-        evaluator.evaluate_if_necessary.return_value = dummy_eval_score
-
-        evaluation_hook = mock.Mock()
-
-        eval_stats_history = pfrl.experiments.train_agent(
-            agent=agent,
-            env=env,
-            steps=5,
-            outdir=outdir,
-            step_hooks=[hook],
-            evaluator=evaluator,
-            evaluation_hooks=[evaluation_hook],
+        assert str(
+            exception.value
+        ) == "{} does not support train_agent_with_evaluation().".format(
+            unsupported_evaluation_hook
         )
-
-        expected = [
-            dict(**dict(dummy_stats), eval_score=dummy_eval_score)
-            for _ in range(n_resets)
-        ]
-        self.assertListEqual(eval_stats_history, expected)
-
-        self.assertEqual(agent.act.call_count, 5)
-        self.assertEqual(agent.observe.call_count, 5)
-        # done=True at state 5
-        self.assertTrue(agent.observe.call_args_list[4][0][2])
-
-        self.assertEqual(env.reset.call_count, 1)
-        self.assertEqual(env.step.call_count, 5)
-
-        self.assertEqual(hook.call_count, 5)
-        # each hook receives (env, agent, step)
-        for i, call in enumerate(hook.call_args_list):
-            args, kwargs = call
-            self.assertEqual(args[0], env)
-            self.assertEqual(args[1], agent)
-            # step starts with 1
-            self.assertEqual(args[2], i + 1)
-
-        # evaluation_hook receives (env, agent, evaluator, t, eval_score)
-        self.assertEqual(evaluation_hook.call_count, n_resets)
-        args = evaluation_hook.call_args[0]
-        self.assertIs(args[0], env)
-        self.assertIs(args[1], agent)
-        self.assertIs(args[2], evaluator)
-        self.assertIs(args[3], 5)
-        self.assertIs(args[4], 42)

--- a/tests/experiments_tests/test_train_agent_async.py
+++ b/tests/experiments_tests/test_train_agent_async.py
@@ -112,6 +112,39 @@ def test_train_agent_async(num_envs, max_episode_len):
     agent.save.assert_called_once_with(os.path.join(outdir, "{}_finish".format(steps)))
 
 
+def test_unsupported_evaluation_hook():
+    class UnsupportedEvaluationHook(pfrl.experiments.evaluation_hooks.EvaluationHook):
+        support_train_agent = True
+        support_train_agent_batch = True
+        support_train_agent_async = False
+
+        def __call__(
+            self,
+            env,
+            agent,
+            evaluator,
+            step,
+            eval_stats,
+            agent_stats,
+            env_stats,
+        ):
+            pass
+
+    unsupported_evaluation_hook = UnsupportedEvaluationHook()
+
+    with pytest.raises(ValueError) as exception:
+        pfrl.experiments.train_agent_async(
+            outdir=mock.Mock(),
+            processes=mock.Mock(),
+            make_env=mock.Mock(),
+            evaluation_hooks=[unsupported_evaluation_hook],
+        )
+
+    assert str(exception.value) == "{} does not support train_agent_async().".format(
+        unsupported_evaluation_hook
+    )
+
+
 class TestTrainLoop(unittest.TestCase):
     def test_needs_reset(self):
 


### PR DESCRIPTION
call evaluation_hooks in `{Async,}Evaluator` instead of `train_agent{,_batch,_async}`.

This PR is a preparation for unifying `evaluation_hooks` to `use_tensorboard` option.
(Interactions with Tensorboard are called in `{Async,}Evaluator`.)

I also added `support_train_agent{,_batch,_async}` attributes to `EvaluationHook` class in order to clarify that which hooks are eligible for each training function (`train_agent_with_evaluation, train_agent_batch_with_evaluation, train_agent_async`).

---

NOTE: This PR breaks backward compatibility of `EvaluationHook.__call__` API. It no longer has `eval_score` argument. Use `eval_stats['mean']` instead (`eval_score` is equivalent to it).