### PR TITLE
Switch to mypy>=0.800

### DIFF
--- a/.pfnci/lint.sh
+++ b/.pfnci/lint.sh
@@ -2,13 +2,11 @@
 
 set -eux
 
-pip3 install black flake8 mypy isort
+pip3 install black flake8 'mypy>=0.800' isort
 
 black --diff --check pfrl tests examples
 isort --diff --check pfrl tests examples
 flake8 pfrl tests examples
-mypy pfrl
-# mypy does not search child directories unless there is __init__.py
-find tests -type f -name "*.py" | xargs dirname | sort | uniq | xargs mypy
+mypy pfrl tests
 # To avoid "duplicate module named xxx.py" errors, run mypy independently for each directory
 find examples -type f -name "*.py" | xargs dirname | sort | uniq | xargs -I{} mypy {}


### PR DESCRIPTION
Resolves #126 

mypy==0.800 searches child directories even if it has no `__init__.py`.

`examples` is kept untouched since it still suffers from "duplicate module" issues.
```
(pfrl) ➜  pfrl git:(mypy-0800) ✗ mypy examples
examples/slimevolley/train_rainbow.py: error: Duplicate module named 'train_rainbow' (also at 'examples/atari/reproduction/rainbow/train_rainbow.py')
examples/slimevolley/train_rainbow.py: error: Are you missing an __init__.py?
Found 2 errors in 1 file (errors prevented further checking)
```