### PR TITLE
Changes reference from chainer to pfrl for pretrained models

### DIFF
--- a/pfrl/utils/pretrained_models.py
+++ b/pfrl/utils/pretrained_models.py
@@ -31,7 +31,7 @@ MODELS = {
     "SAC": ["best", "final"],
 }
 
-download_url = "https://chainer-assets.preferred.jp/pfrl/"
+download_url = "https://pfrl-assets.preferred.jp/"
 
 
 def _get_model_directory(model_name, create_directory=True):


### PR DESCRIPTION
To check that this works, simply test the pretrained model commands for the pretrained models. I.e., try using the `--load-pretrained` flag for the pretrained model scripts. It should load the networks and produce good performance. 

Essentially, we just change the URL reference to the pretrained model directory on AWS (done internally within the company). This PR uses that new URL reference so that we can reduce references to chainer.