### PR TITLE
fix IndexError due to empty stack

### DIFF
--- a/pfrl/agents/ppo.py
+++ b/pfrl/agents/ppo.py
@@ -161,7 +161,7 @@ def _yield_subset_of_sequences_with_fixed_number_of_items(sequences, n_items):
     while stack:
         subset = []
         count = 0
-        while count < n_items:
+        while count < n_items and stack:
             sequence = stack.pop()
             subset.append(sequence)
             count += len(sequence)
@@ -172,8 +172,11 @@ def _yield_subset_of_sequences_with_fixed_number_of_items(sequences, n_items):
             assert n_exceeds > 0
             subset[-1] = sequence_to_split[:-n_exceeds]
             stack.append(sequence_to_split[-n_exceeds:])
-        assert sum(len(seq) for seq in subset) == n_items
-        yield subset
+        if sum(len(seq) for seq in subset) == n_items:
+            yield subset
+        else:
+            # This ends the while loop.
+            assert len(stack) == 0
 
 
 def _compute_explained_variance(transitions):


### PR DESCRIPTION
The original [method](https://github.com/pfnet/pfrl/blob/67bd517375bf35cd44421e964c518456d4b6f089/pfrl/agents/ppo.py#L158) can cause IndexError in some cases.  

I stumbled on this bug in my experiments and one way to reproduce the error is to modify the method's inputs to `sequences = [sequences[0][:17]]` and `n_items = 4`.
The fix in this PR is simple, it may not be the optimal though.