### PR TITLE
[WIP] Snapshot for preemption

### DIFF
--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -69,7 +69,7 @@ def main():
     parser.add_argument("--render-eval", action="store_true")
     parser.add_argument("--monitor", action="store_true")
     parser.add_argument("--reward-scale-factor", type=float, default=1e-3)
-    parser.add_argument('--load_snapshot', action='store_true')
+    parser.add_argument("--load_snapshot", action="store_true")
     parser.add_argument(
         "--actor-learner",
         action="store_true",

--- a/examples/gym/train_dqn_gym.py
+++ b/examples/gym/train_dqn_gym.py
@@ -90,6 +90,9 @@ def main():
     utils.set_random_seed(args.seed)
 
     args.outdir = experiments.prepare_output_dir(args, args.outdir, argv=sys.argv)
+    # TODO: fix output directory for now!!
+    args.outdir = "results/tmp"
+    os.makedirs(args.outdir, exist_ok=True)
     print("Output files are saved in {}".format(args.outdir))
 
     # Set different random seeds for different subprocesses.

--- a/pfrl/experiments/__init__.py
+++ b/pfrl/experiments/__init__.py
@@ -7,7 +7,7 @@ from pfrl.experiments.prepare_output_dir import generate_exp_id  # NOQA
 from pfrl.experiments.prepare_output_dir import is_under_git_control  # NOQA
 from pfrl.experiments.prepare_output_dir import prepare_output_dir  # NOQA
 from pfrl.experiments.train_agent import train_agent  # NOQA
-from pfrl.experiments.train_agent import train_agent_with_evaluation  # NOQA
+from pfrl.experiments.train_agent import train_agent_with_evaluation, load_snapshot, latest_snapshot_dir  # NOQA
 from pfrl.experiments.train_agent_async import train_agent_async  # NOQA
 from pfrl.experiments.train_agent_batch import train_agent_batch  # NOQA
 from pfrl.experiments.train_agent_batch import train_agent_batch_with_evaluation  # NOQA

--- a/pfrl/experiments/__init__.py
+++ b/pfrl/experiments/__init__.py
@@ -7,7 +7,11 @@ from pfrl.experiments.prepare_output_dir import generate_exp_id  # NOQA
 from pfrl.experiments.prepare_output_dir import is_under_git_control  # NOQA
 from pfrl.experiments.prepare_output_dir import prepare_output_dir  # NOQA
 from pfrl.experiments.train_agent import train_agent  # NOQA
-from pfrl.experiments.train_agent import train_agent_with_evaluation, load_snapshot, latest_snapshot_dir  # NOQA
+from pfrl.experiments.train_agent import (
+    train_agent_with_evaluation,
+    load_snapshot,
+    latest_snapshot_dir,
+)  # NOQA
 from pfrl.experiments.train_agent_async import train_agent_async  # NOQA
 from pfrl.experiments.train_agent_batch import train_agent_batch  # NOQA
 from pfrl.experiments.train_agent_batch import train_agent_batch_with_evaluation  # NOQA

--- a/pfrl/experiments/train_agent.py
+++ b/pfrl/experiments/train_agent.py
@@ -24,10 +24,14 @@ def ask_and_save_agent_replay_buffer(agent, t, outdir, suffix=""):
         save_agent_replay_buffer(agent, t, outdir, suffix=suffix)
 
 
-def snapshot(agent, evaluator, t, outdir, suffix="_snapshot", logger=None, delete_old=True):
+def snapshot(
+    agent, evaluator, t, outdir, suffix="_snapshot", logger=None, delete_old=True
+):
     tmp_suffix = f"{suffix}_"
     dirname = os.path.join(outdir, f"{t}{suffix}")
-    tmp_dirname = os.path.join(outdir, f"{t}{tmp_suffix}")  # temporary filename until files are saved
+    tmp_dirname = os.path.join(
+        outdir, f"{t}{tmp_suffix}"
+    )  # temporary filename until files are saved
     agent.save(tmp_dirname)
     if hasattr(agent, "replay_buffer"):
         agent.replay_buffer.save(os.path.join(tmp_dirname, "replay.pkl"))
@@ -37,7 +41,9 @@ def snapshot(agent, evaluator, t, outdir, suffix="_snapshot", logger=None, delet
     if logger:
         logger.info(f"Saved the snapshot to {dirname}")
     if delete_old:
-        for old_dir in filter(lambda s: s.endswith(suffix) or s.endswith(tmp_suffix), os.listdir(outdir)):
+        for old_dir in filter(
+            lambda s: s.endswith(suffix) or s.endswith(tmp_suffix), os.listdir(outdir)
+        ):
             if old_dir != f"{t}{suffix}":
                 shutil.rmtree(os.path.join(outdir, old_dir))
 
@@ -58,7 +64,12 @@ def latest_snapshot_dir(search_dir, suffix="_snapshot"):
     candidates = list(filter(lambda s: s.endswith(suffix), os.listdir(search_dir)))
     if len(candidates) == 0:
         return 0, None
-    return max([(int(name.split("_")[0]), os.path.join(search_dir, name)) for name in candidates])
+    return max(
+        [
+            (int(name.split("_")[0]), os.path.join(search_dir, name))
+            for name in candidates
+        ]
+    )
 
 
 def train_agent(


### PR DESCRIPTION
Current pfrl does not support snapshot of training, which is important in many job systems such as Kubernetes.
This PR support saving and loading snapshot including replay buffer. 

## Done
- save & load snapshot
  - agent, replay buffer, step_offset, max_score
- test locally by `python examples/gym/train_dqn_gym.py --env CartPole-v0 --steps=5000 --eval-n-runs=10 --eval-interval=1000 --load_snapshot --checkpoint-freq=1000`

## Not Done
- reflect on examples/* (Do we just need to create one separate example for snapshot?)
- log (scores.txt)
- test script