### PR TITLE
Fix CI error due to gym's version

### DIFF
--- a/.pfnci/run.sh
+++ b/.pfnci/run.sh
@@ -75,7 +75,7 @@ main() {
   # pytest does not run with attrs==19.2.0 (https://github.com/pytest-dev/pytest/issues/3280)  # NOQA
   "${PYTHON}" -m pip install \
       'pytest==4.1.1' 'attrs==19.1.0' 'pytest-xdist==1.26.1' \
-      'atari_py==0.1.1' 'opencv-python' 'optuna' 'zipp==1.0.0' 'pybullet==2.8.1' 'jupyterlab==2.1.5'
+      'gym[atari,classic_control]==0.19.0' 'optuna' 'zipp==1.0.0' 'pybullet==2.8.1' 'jupyterlab==2.1.5'
 
   git config --global user.email "you@example.com"
   git config --global user.name "Your Name"


### PR DESCRIPTION
Resolves #158 

Why this PR resolves the issue:
- Since `gym==0.19.0`, `pip install gym` no longer install `pyglet`, which causes this error since the monitor functionality of classic control envs requires pyglet.
- Now users need to install `gym[classic_control]` so that pyglet is also installed.

Both atari_py and opencv-python are included in gym[atari], so it must be safe to stop installing them manually. See https://github.com/openai/gym/blob/a4c3f15e9b0c7525ec9006e92a3bf6bc8bd0a798/setup.py#L11-L19