### PR TITLE
Fix mypy error due to numbers.Number

### DIFF
--- a/pfrl/collections/prioritized.py
+++ b/pfrl/collections/prioritized.py
@@ -1,5 +1,4 @@
 import collections
-from numbers import Number
 from typing import (
     Any,
     Callable,
@@ -243,7 +242,7 @@ class TreeQueue(Generic[V]):
         return ret
 
 
-def _find(index_left: int, index_right: int, node: Node, pos: Number) -> int:
+def _find(index_left: int, index_right: int, node: Node, pos: float) -> int:
     if index_right - index_left == 1:
         return index_left
     else:


### PR DESCRIPTION
Resolves #170 .

`float` might be narrower than `Number` as a type, but I don't think this is a issue here since the `_find` function is used with float only.