### PR TITLE
Fixed save/load problem on dqn.py

### DIFF
--- a/pfrl/agents/dqn.py
+++ b/pfrl/agents/dqn.py
@@ -791,8 +791,8 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         if self.recurrent:
             self.test_recurrent_states = None
 
-    def save(self, dirname: str) -> None:
-        super().save(dirname)
+    def save_snapshot(self, dirname: str) -> None:
+        self.save(dirname)
         torch.save(
             self.t, os.path.join(dirname, "t.pt")
         )
@@ -807,8 +807,8 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
         )
 
 
-    def load(self, dirname: str) -> None:
-        super().load(dirname)
+    def load_snapshot(self, dirname: str) -> None:
+        self.load(dirname)
         self.t = torch.load(
             os.path.join(dirname, "t.pt")
         )

--- a/pfrl/agents/dqn.py
+++ b/pfrl/agents/dqn.py
@@ -4,6 +4,7 @@ import ctypes
 import multiprocessing as mp
 import multiprocessing.synchronize
 import time
+import os
 from logging import Logger, getLogger
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -789,6 +790,37 @@ class DQN(agent.AttributeSavingMixin, agent.BatchAgent):
     def stop_episode(self) -> None:
         if self.recurrent:
             self.test_recurrent_states = None
+
+    def save(self, dirname: str) -> None:
+        super().save(dirname)
+        torch.save(
+            self.t, os.path.join(dirname, "t.pt")
+        )
+        torch.save(
+            self.optim_t, os.path.join(dirname, "optim_t.pt")
+        )
+        torch.save(
+            self._cumulative_steps, os.path.join(dirname, "_cumulative_steps.pt")
+        )
+        self.replay_buffer.save(
+            os.path.join(dirname, "replay_buffer.pkl")
+        )
+
+
+    def load(self, dirname: str) -> None:
+        super().load(dirname)
+        self.t = torch.load(
+            os.path.join(dirname, "t.pt")
+        )
+        self.optim_t = torch.load(
+            os.path.join(dirname, "optim_t.pt")
+        )
+        self._cumulative_steps = torch.load(
+            os.path.join(dirname, "_cumulative_steps.pt")
+        )
+        self.replay_buffer.load(
+            os.path.join(dirname, "replay_buffer.pkl")
+        )
 
     def get_statistics(self):
         return [


### PR DESCRIPTION
Saving and loading the DQN agent would not save/load four needed attributes:
- self.t
- self.optim_t
- self._cumulative_steps
- self.replay_buffer

This caused the agent to have different a performance when evaluated without killing the program vs when saving the agent, killing the program, resuming the program and loading the agent.

Fig 1 - Training without checkpoints (i.e. same program ran from start to finish)
![plot](https://github.com/pfnet/pfrl/assets/13886272/83063971-a6d4-435b-9f21-e90e3f7b4f29)

Fig 2 - Training with checkpoint (i.e., program killed at every t steps and agents loaded from disk)
![plot](https://github.com/pfnet/pfrl/assets/13886272/0ed8decb-5e4a-47e4-9c5d-34ae256f0b97) 

My proposed solution (working, but applied only to the DQN agent) was to add new save_snapshot and load_snapshot methods on the agent's class (without overwriting the original save and load methods, avoiding saving the replay buffer every time):

```
    def save_snapshot(self, dirname: str) -> None:
        self.save(dirname)
        torch.save(
            self.t, os.path.join(dirname, "t.pt")
        )
        torch.save(
            self.optim_t, os.path.join(dirname, "optim_t.pt")
        )
        torch.save(
            self._cumulative_steps, os.path.join(dirname, "_cumulative_steps.pt")
        )
        self.replay_buffer.save(
            os.path.join(dirname, "replay_buffer.pkl")
        )


    def load_snapshot(self, dirname: str) -> None:
        self.load(dirname)
        self.t = torch.load(
            os.path.join(dirname, "t.pt")
        )
        self.optim_t = torch.load(
            os.path.join(dirname, "optim_t.pt")
        )
        self._cumulative_steps = torch.load(
            os.path.join(dirname, "_cumulative_steps.pt")
        )
        self.replay_buffer.load(
            os.path.join(dirname, "replay_buffer.pkl")
        )
```

This change is working as intended, training is resumed properly after reloading the agent from disk:

Fig 3 - Training with checkpoint (New patch) (i.e., program killed at every t steps and agents loaded from disk)
![image](https://github.com/pfnet/pfrl/assets/13886272/11d4dda3-35cb-440e-9a13-5e936badfcdb)