### PR TITLE
Adds errata for Rainbow

### DIFF
--- a/examples/atari/reproduction/rainbow/README.md
+++ b/examples/atari/reproduction/rainbow/README.md
@@ -33,7 +33,11 @@ To view the full list of options, either view the code or run the example with t
 
 
 ## Results
-These results reflect PFRL commit hash:  `a0ad6a7`.
+
+These results reflect PFRL commit hash:  `a0ad6a7`. 
+**Errata: In the original Rainbow paper, the target network was updated every 8000 timesteps, not 32000. The file remains the same as it is the file generating the results.**
+- Source: [Original Rainbow paper - Table 1](https://arxiv.org/pdf/1710.02298)
+- Code: [DQN Zoo Reproduction](https://github.com/google-deepmind/dqn_zoo/blob/master/dqn_zoo/rainbow/run_atari.py#L74)
 
 | Results Summary ||
 | ------------- |:-------------:|

--- a/examples/atari/reproduction/rainbow/train_rainbow.py
+++ b/examples/atari/reproduction/rainbow/train_rainbow.py
@@ -152,7 +152,8 @@ def main():
         explorer=explorer,
         minibatch_size=32,
         replay_start_size=args.replay_start_size,
-        target_update_interval=32000, # errata: Should be 8000 steps to match the original paper.
+        # errata: target_update_interval should be 8000 to match original paper.
+        target_update_interval=32000,
         update_interval=update_interval,
         batch_accumulator="mean",
         phi=phi,

--- a/examples/atari/reproduction/rainbow/train_rainbow.py
+++ b/examples/atari/reproduction/rainbow/train_rainbow.py
@@ -152,7 +152,7 @@ def main():
         explorer=explorer,
         minibatch_size=32,
         replay_start_size=args.replay_start_size,
-        target_update_interval=32000,
+        target_update_interval=32000, # errata: 8000 in paper is in units of steps, here in units of updates
         update_interval=update_interval,
         batch_accumulator="mean",
         phi=phi,

--- a/examples/atari/reproduction/rainbow/train_rainbow.py
+++ b/examples/atari/reproduction/rainbow/train_rainbow.py
@@ -152,7 +152,7 @@ def main():
         explorer=explorer,
         minibatch_size=32,
         replay_start_size=args.replay_start_size,
-        target_update_interval=32000, # errata: 8000 in paper is in units of steps, here in units of updates
+        target_update_interval=32000, # errata: Should be 8000 steps to match the original paper.
         update_interval=update_interval,
         batch_accumulator="mean",
         phi=phi,


### PR DESCRIPTION
- A hyperparameter (the target network update interval) is incorrect in the reproduction of Rainbow. This PR makes a note to clarify this issue.